### PR TITLE
Move bs-jest to dev-dependencies and use bsrefmt

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -4,9 +4,12 @@
   "bsc-flags": ["-bs-super-errors"],
   "sources": [
     "src",
-    "__tests__"
+    {
+      "dir": "__tests__",
+      "type": "dev"
+    }
   ],
-  "bs-dependencies": [
+  "bs-dev-dependencies": [
     "bs-jest"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "scripts": {
     "clean": "bsb -clean-world",
-    "generate": "node scripts/generate.js && refmt --in-place src/jsonCodec_object.re",
+    "generate": "node scripts/generate.js && bsrefmt --in-place src/jsonCodec_object.re",
     "build": "npm run generate && bsb -make-world",
     "watch": "bsb -make-world -w",
     "test": "npm run build && jest",
-    "format": "refmt --in-place src/*.re"
+    "format": "bsrefmt --in-place src/*.re"
   },
   "keywords": [
     "JSON",


### PR DESCRIPTION
I have noticed that `json-codec` is missing `bs-jest` as its dependency when as a dependency itself. This meant that I couldn't build my project without having installed `bs-jest` myself.

Additionally, I have changed `refmt` to `bsrefmt`, because apparenly
that is the one included in `bs-platform`