### PR TITLE
upgradeSyntaxFrom2To3

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,26 @@ let json = {js|
 /* Define a codec for the above object type */
 let codec =
   JsonCodec.(
-    object4
-      (field "name" string) (field "lat" number) (field "long" number) (field "height" number)
+    object4(
+      field("name", string),
+      field("lat", number),
+      field("long", number),
+      field("height", number)
+    )
   );
 
 /* Decoding */
-let () =
-  switch (JsonCodec.decodeJson codec json) {
-  | Js.Result.Ok (name, lat, lon, height) =>
-    Printf.printf "name='%s' location=%f,%f height=%f\n" name lat lon height
-  | Js.Result.Error error => Printf.printf "Decoding error: %s" error
-  };
+switch (JsonCodec.decodeJson(codec, json)) {
+| Js.Result.Ok((name, lat, lon, height)) =>
+  Printf.printf("name='%s' location=%f,%f height=%f\n", name, lat, lon, height)
+| Js.Result.Error(error) => Printf.printf("Decoding error: %s", error)
+};
 
 /* Encoding */
-let encoded = JsonCodec.encodeJson codec ("Machu Picchu", -13.163333, -72.545556, 2430.0);
+let encoded =
+  JsonCodec.encodeJson(codec, ("Machu Picchu", -13.163333, -72.545556, 2430.0));
 
-let () = Printf.printf "JSON: %s\n" encoded;
+Printf.printf("JSON: %s\n", encoded);
 ```
 
 

--- a/__tests__/jsonCodecTest.re
+++ b/__tests__/jsonCodecTest.re
@@ -1,472 +1,676 @@
 open Jest;
+
 module C = JsonCodec;
 
-let formatJsonString s => Js.Json.parseExn s |> Js.Json.stringify;
+let formatJsonString = s => Js.Json.parseExn(s) |> Js.Json.stringify;
 
-type tree 'a =
-  | Leaf 'a
-  | Branch (tree 'a) (tree 'a);
+type tree('a) =
+  | Leaf('a)
+  | Branch(tree('a), tree('a));
 
 let () =
-  describe "JsonCodec"
-    ExpectJs.(fun () => {
-      let jsonString = "\"foo\"";
-      let jsonNumberArray = formatJsonString "[1.1, 2.2]";
-      let jsonEmptyObject = "{}";
-      let jsonSingleStringFieldObject = formatJsonString {js|{"foo": "bar"}|js};
-      let jsonSingleNumberFieldObject = formatJsonString {js|{"foo": 12.34}|js};
-      let jsonTwoFieldObject = formatJsonString {js|{"foo": "bar", "baz": true}|js};
-      let jsonThreeFieldObject = formatJsonString {js|{"foo": "bar", "baz": true, "qux": 56.78}|js};
-      let jsonFourFieldObject = formatJsonString {js|{"foo": "bar", "baz": true, "qux": 56.78, "quux": null}|js};
-
-      describe "number" (fun () => {
-        test "encoding" (fun () =>
-          expect (C.encodeJson C.number 3.14) |> toEqual "3.14"
-        );
-        test "decoding success" (fun () =>
-          expect (C.decodeJson C.number "3.14") |> toEqual (Js.Result.Ok 3.14)
-        );
-        test "decoding failure, not a number" (fun () =>
-          expect (C.decodeJson C.number jsonString) |> toEqual (Js.Result.Error "Expected number")
-        );
-        test "decoding failure, invalid JSON" (fun () =>
-          expect (C.decodeJson C.number "_") |> toEqual (Js.Result.Error "Unexpected token _ in JSON at position 0")
-        );
-      });
-
-      describe "int" (fun () => {
-        test "encoding" (fun () =>
-          expect (C.encodeJson C.int 1) |> toEqual "1"
-        );
-        test "decoding success, no decimal point" (fun () =>
-          expect (C.decodeJson C.int "1") |> toEqual (Js.Result.Ok 1)
-        );
-        test "decoding success, zero after decimal point" (fun () =>
-          expect (C.decodeJson C.int "1.0") |> toEqual (Js.Result.Ok 1)
-        );
-        test "decoding failure, can't represent as int" (fun () =>
-          expect (C.decodeJson C.int "1.234") |> toEqual (Js.Result.Error "Not an int: 1.234")
-        );
-      });
-
-      describe "string" (fun () => {
-        test "encoding" (fun () =>
-          expect (C.encodeJson C.string "foo") |> toEqual jsonString
-        );
-        test "decoding success" (fun () =>
-          expect (C.decodeJson C.string jsonString) |> toEqual (Js.Result.Ok "foo")
-        );
-        test "decoding failure" (fun () =>
-          expect (C.decodeJson C.string "0.5") |> toEqual (Js.Result.Error "Expected string")
-        );
-      });
-
-      describe "bool" (fun () => {
-        test "encoding" (fun () =>
-          expect (C.encodeJson C.bool true) |> toEqual "true"
-        );
-        test "decoding success" (fun () =>
-          expect (C.decodeJson C.bool "false") |> toEqual (Js.Result.Ok false)
-        );
-        test "decoding failure" (fun () =>
-          expect (C.decodeJson C.bool jsonString) |> toEqual (Js.Result.Error "Expected boolean")
-        );
-      });
-
-      describe "null" (fun () => {
-        test "encoding" (fun () =>
-          expect (C.encodeJson C.null ()) |> toEqual "null"
-        );
-        test "decoding success" (fun () =>
-          expect (C.decodeJson C.null "null") |> toEqual (Js.Result.Ok ())
-        );
-        test "decoding failure" (fun () =>
-          expect (C.decodeJson C.null "true") |> toEqual (Js.Result.Error "Expected null")
-        );
-      });
-
-      describe "nullable" (fun () => {
-        test "empty encoding" (fun () =>
-          expect (C.encodeJson (C.nullable C.string) None) |> toEqual "null"
-        );
-        test "empty decoding success" (fun () =>
-          expect (C.decodeJson (C.nullable C.string) "null") |> toEqual (Js.Result.Ok None)
-        );
-        test "non-empty encoding" (fun () =>
-          expect (C.encodeJson (C.nullable C.string) (Some "foo")) |> toEqual jsonString
-        );
-        test "non-empty decoding success" (fun () =>
-          expect (C.decodeJson (C.nullable C.number) "1.0") |> toEqual (Js.Result.Ok (Some 1.0))
-        );
-        test "decoding failure" (fun () =>
-          expect (C.decodeJson (C.nullable C.string) "1.0") |> toEqual (Js.Result.Error "Expected string")
-        );
-      });
-
-      describe "array" (fun () => {
-        test "empty encoding" (fun () =>
-          expect (C.encodeJson (C.array C.number) [||]) |> toEqual "[]"
-        );
-        test "empty decoding" (fun () =>
-          expect (C.decodeJson (C.array C.string) "[]") |> toEqual (Js.Result.Ok [||])
-        );
-        test "non-empty encoding" (fun () =>
-          expect (C.encodeJson (C.array C.number) [| 1.1, 2.2 |] |> formatJsonString) |> toEqual jsonNumberArray
-        );
-        test "non-empty decoding success" (fun () =>
-          expect (C.decodeJson (C.array C.number) jsonNumberArray) |> toEqual (Js.Result.Ok [| 1.1, 2.2 |])
-        );
-        test "decoding failure" (fun () =>
-          expect (C.decodeJson (C.array C.string) "true") |> toEqual (Js.Result.Error "Expected array")
-        );
-        test "element decoding failure" (fun () =>
-          expect (C.decodeJson (C.array C.string) jsonNumberArray) |> toEqual (Js.Result.Error "Expected string")
-        );
-      });
-
-      describe "object0" (fun () => {
-        test "encoding" (fun () =>
-          expect (C.encodeJson C.object0 ()) |> toEqual "{}"
-        );
-        test "decoding success" (fun () =>
-          expect (C.decodeJson C.object0 "{}") |> toEqual (Js.Result.Ok ())
-        );
-        test "decoding success, ignoring extra fields" (fun () =>
-          expect (C.decodeJson C.object0 jsonSingleStringFieldObject) |> toEqual (Js.Result.Ok ())
-        );
-        test "decoding failure" (fun () =>
-          expect (C.decodeJson C.object0 "null") |> toEqual (Js.Result.Error "Expected object")
-        );
-      });
-
-      describe "object1" (fun () => {
-        let codec = C.object1 (C.field "foo" C.string);
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec "bar") |> toEqual jsonSingleStringFieldObject
-        );
-        test "decoding success" (fun () =>
-          expect (C.decodeJson codec jsonSingleStringFieldObject) |> toEqual (Js.Result.Ok "bar")
-        );
-        test "decoding success, ignoring extra fields" (fun () =>
-          expect (C.decodeJson codec jsonTwoFieldObject) |> toEqual (Js.Result.Ok "bar")
-        );
-        test "decoding failure, not an object" (fun () =>
-          expect (C.decodeJson codec "false") |> toEqual (Js.Result.Error "Expected object")
-        );
-        test "decoding failure, missing field" (fun () =>
-          expect (C.decodeJson codec "{}") |> toEqual (Js.Result.Error "Field 'foo' not found")
-        );
-        test "decoding failure, wrong field type" (fun () =>
-          expect (C.decodeJson codec jsonSingleNumberFieldObject) |> toEqual (Js.Result.Error "Expected string")
-        );
-      });
-
-      describe "object2" (fun () => {
-        let codec = C.object2 (C.field "foo" C.string) (C.field "baz" C.bool);
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec ("bar", true)) |> toEqual jsonTwoFieldObject
-        );
-        test "decoding success" (fun () => {
-          expect (C.decodeJson codec jsonTwoFieldObject) |> toEqual (Js.Result.Ok ("bar", true))
-        });
-        test "decoding success, ignoring extra fields" (fun () => {
-          expect (C.decodeJson codec jsonThreeFieldObject) |> toEqual (Js.Result.Ok ("bar", true))
-        });
-        test "decoding failure, not an object" (fun () =>
-          expect (C.decodeJson codec "7.77") |> toEqual (Js.Result.Error "Expected object")
-        );
-        test "decoding failure, missing field" (fun () =>
-          expect (C.decodeJson codec jsonSingleStringFieldObject) |> toEqual (Js.Result.Error "Field 'baz' not found")
-        );
-        test "decoding failure, wrong field type" (fun () =>
-          expect (C.decodeJson codec jsonSingleNumberFieldObject) |> toEqual (Js.Result.Error "Expected string")
-        );
-      });
-
-      describe "object3" (fun () => {
-        let codec = C.object3 (C.field "foo" C.string) (C.field "baz" C.bool) (C.field "qux" C.number);
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec ("bar", true, 56.78)) |> toEqual jsonThreeFieldObject
-        );
-        test "decoding success" (fun () => {
-          expect (C.decodeJson codec jsonThreeFieldObject) |> toEqual (Js.Result.Ok ("bar", true, 56.78))
-        });
-        test "decoding success, ignoring extra fields" (fun () => {
-          expect (C.decodeJson codec jsonFourFieldObject) |> toEqual (Js.Result.Ok ("bar", true, 56.78))
-        });
-        test "decoding failure, not an object" (fun () =>
-          expect (C.decodeJson codec "null") |> toEqual (Js.Result.Error "Expected object")
-        );
-        test "decoding failure, missing field" (fun () =>
-          expect (C.decodeJson codec jsonTwoFieldObject) |> toEqual (Js.Result.Error "Field 'qux' not found")
-        );
-        test "decoding failure, wrong field type" (fun () =>
-          expect (C.decodeJson codec jsonSingleNumberFieldObject) |> toEqual (Js.Result.Error "Expected string")
-        );
-      });
-
-      describe "object4" (fun () => {
-        let codec = C.object4 (C.field "foo" C.string) (C.field "baz" C.bool) (C.field "qux" C.number) (C.field "quux" C.null);
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec ("bar", true, 56.78, ())) |> toEqual jsonFourFieldObject
-        );
-        test "decoding" (fun () =>
-          expect (C.decodeJson codec jsonFourFieldObject) |> toEqual (Js.Result.Ok ("bar", true, 56.78, ()))
-        );
-      });
-
-      describe "object5" (fun () => {
-        let json = formatJsonString {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5}|js};
-        let codec = C.object5 (C.field "f1" C.int) (C.field "f2" C.int) (C.field "f3" C.int) (C.field "f4" C.int) (C.field "f5" C.int);
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec (1, 2, 3, 4, 5)) |> toEqual json
-        );
-        test "decoding" (fun () =>
-          expect (C.decodeJson codec json) |> toEqual (Js.Result.Ok (1, 2, 3, 4, 5))
-        );
-      });
-
-      describe "object6" (fun () => {
-        let json = formatJsonString {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5, "f6": 6}|js};
-        let codec = C.object6 (C.field "f1" C.int) (C.field "f2" C.int) (C.field "f3" C.int) (C.field "f4" C.int) (C.field "f5" C.int) (C.field "f6" C.int);
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec (1, 2, 3, 4, 5, 6)) |> toEqual json
-        );
-        test "decoding" (fun () =>
-          expect (C.decodeJson codec json) |> toEqual (Js.Result.Ok (1, 2, 3, 4, 5, 6))
-        );
-      });
-
-      describe "object7" (fun () => {
-        let json = formatJsonString {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5, "f6": 6, "f7": 7}|js};
-        let codec = C.object7 (C.field "f1" C.int) (C.field "f2" C.int) (C.field "f3" C.int) (C.field "f4" C.int) (C.field "f5" C.int) (C.field "f6" C.int) (C.field "f7" C.int);
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec (1, 2, 3, 4, 5, 6, 7)) |> toEqual json
-        );
-        test "decoding" (fun () =>
-          expect (C.decodeJson codec json) |> toEqual (Js.Result.Ok (1, 2, 3, 4, 5, 6, 7))
-        );
-      });
-
-      describe "object8" (fun () => {
-        let json = formatJsonString {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5, "f6": 6, "f7": 7, "f8": 8}|js};
-        let codec = C.object8 (C.field "f1" C.int) (C.field "f2" C.int) (C.field "f3" C.int) (C.field "f4" C.int) (C.field "f5" C.int) (C.field "f6" C.int) (C.field "f7" C.int) (C.field "f8" C.int);
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec (1, 2, 3, 4, 5, 6, 7, 8)) |> toEqual json
-        );
-        test "decoding" (fun () =>
-          expect (C.decodeJson codec json) |> toEqual (Js.Result.Ok (1, 2, 3, 4, 5, 6, 7, 8))
-        );
-      });
-
-      describe "object9" (fun () => {
-        let json = formatJsonString {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5, "f6": 6, "f7": 7, "f8": 8, "f9": 9}|js};
-        let codec = C.object9 (C.field "f1" C.int) (C.field "f2" C.int) (C.field "f3" C.int) (C.field "f4" C.int) (C.field "f5" C.int) (C.field "f6" C.int) (C.field "f7" C.int) (C.field "f8" C.int) (C.field "f9" C.int);
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec (1, 2, 3, 4, 5, 6, 7, 8, 9)) |> toEqual json
-        );
-        test "decoding" (fun () =>
-          expect (C.decodeJson codec json) |> toEqual (Js.Result.Ok (1, 2, 3, 4, 5, 6, 7, 8, 9))
-        );
-      });
-
-      describe "object10" (fun () => {
-        let json = formatJsonString {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5, "f6": 6, "f7": 7, "f8": 8, "f9": 9, "f10": 10}|js};
-        let codec = C.object10 (C.field "f1" C.int) (C.field "f2" C.int) (C.field "f3" C.int) (C.field "f4" C.int) (C.field "f5" C.int) (C.field "f6" C.int) (C.field "f7" C.int) (C.field "f8" C.int) (C.field "f9" C.int) (C.field "f10" C.int);
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) |> toEqual json
-        );
-        test "decoding" (fun () =>
-          expect (C.decodeJson codec json) |> toEqual (Js.Result.Ok (1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
-        );
-      });
-
-      describe "optional and nullable fields" (fun () => {
-        let nullableFieldCodec = C.(object1 (field "foo" (nullable string)));
-        let optionalFieldCodec = C.(object1 (optional "foo" string));
-        let optionalNullableFieldCodec = C.(object1 (optional "foo" (nullable string)));
-        let flattenedFieldCodec = C.(object1 (C.optionalNullable "foo" string));
-
-        let jsonNullField = formatJsonString "{\"foo\": null}";
-
-        describe "nullable field" (fun () => {
-          test "empty encoding" (fun () =>
-            expect (C.encodeJson spaces::0 nullableFieldCodec None) |> toEqual jsonNullField
+  describe(
+    "JsonCodec",
+    ExpectJs.(
+      () => {
+        let jsonString = "\"foo\"";
+        let jsonNumberArray = formatJsonString("[1.1, 2.2]");
+        let jsonEmptyObject = "{}";
+        let jsonSingleStringFieldObject =
+          formatJsonString({js|{"foo": "bar"}|js});
+        let jsonSingleNumberFieldObject =
+          formatJsonString({js|{"foo": 12.34}|js});
+        let jsonTwoFieldObject =
+          formatJsonString({js|{"foo": "bar", "baz": true}|js});
+        let jsonThreeFieldObject =
+          formatJsonString({js|{"foo": "bar", "baz": true, "qux": 56.78}|js});
+        let jsonFourFieldObject =
+          formatJsonString(
+            {js|{"foo": "bar", "baz": true, "qux": 56.78, "quux": null}|js},
           );
-          test "empty decoding" (fun () =>
-            expect (C.decodeJson nullableFieldCodec jsonNullField) |> toEqual (Js.Result.Ok None)
+        describe("number", () => {
+          test("encoding", () =>
+            expect(C.encodeJson(C.number, 3.14)) |> toEqual("3.14")
           );
-          test "non-empty encoding" (fun () =>
-            expect (C.encodeJson spaces::0 nullableFieldCodec (Some "bar")) |> toEqual jsonSingleStringFieldObject
+          test("decoding success", () =>
+            expect(C.decodeJson(C.number, "3.14"))
+            |> toEqual(Js.Result.Ok(3.14))
           );
-          test "non-empty decoding" (fun () =>
-            expect (C.decodeJson nullableFieldCodec jsonSingleStringFieldObject) |> toEqual (Js.Result.Ok (Some "bar"))
+          test("decoding failure, not a number", () =>
+            expect(C.decodeJson(C.number, jsonString))
+            |> toEqual(Js.Result.Error("Expected number"))
+          );
+          test("decoding failure, invalid JSON", () =>
+            expect(C.decodeJson(C.number, "_"))
+            |> toEqual(
+                 Js.Result.Error("Unexpected token _ in JSON at position 0"),
+               )
           );
         });
-
-        describe "optional field" (fun () => {
-          test "empty encoding" (fun () =>
-            expect (C.encodeJson optionalFieldCodec None) |> toEqual jsonEmptyObject
+        describe("int", () => {
+          test("encoding", () =>
+            expect(C.encodeJson(C.int, 1)) |> toEqual("1")
           );
-          test "empty decoding" (fun () =>
-            expect (C.decodeJson optionalFieldCodec jsonEmptyObject) |> toEqual (Js.Result.Ok None)
+          test("decoding success, no decimal point", () =>
+            expect(C.decodeJson(C.int, "1")) |> toEqual(Js.Result.Ok(1))
           );
-          test "non-empty encoding" (fun () =>
-            expect (C.encodeJson spaces::0 optionalFieldCodec (Some "bar")) |> toEqual jsonSingleStringFieldObject
+          test("decoding success, zero after decimal point", () =>
+            expect(C.decodeJson(C.int, "1.0")) |> toEqual(Js.Result.Ok(1))
           );
-          test "non-empty decoding success" (fun () =>
-            expect (C.decodeJson optionalFieldCodec jsonSingleStringFieldObject) |> toEqual (Js.Result.Ok (Some "bar"))
-          );
-          test "non-empty decoding failure" (fun () =>
-            expect (C.decodeJson optionalFieldCodec jsonSingleNumberFieldObject) |> toEqual (Js.Result.Error "Expected string")
+          test("decoding failure, can't represent as int", () =>
+            expect(C.decodeJson(C.int, "1.234"))
+            |> toEqual(Js.Result.Error("Not an int: 1.234"))
           );
         });
-
-        describe "optional nullable field" (fun () => {
-          test "empty encoding" (fun () =>
-            expect (C.encodeJson optionalNullableFieldCodec None) |> toEqual jsonEmptyObject
+        describe("string", () => {
+          test("encoding", () =>
+            expect(C.encodeJson(C.string, "foo")) |> toEqual(jsonString)
           );
-          test "empty decoding" (fun () =>
-            expect (C.decodeJson optionalNullableFieldCodec jsonEmptyObject) |> toEqual (Js.Result.Ok None)
+          test("decoding success", () =>
+            expect(C.decodeJson(C.string, jsonString))
+            |> toEqual(Js.Result.Ok("foo"))
           );
-          test "null encoding" (fun () =>
-            expect (C.encodeJson spaces::0 optionalNullableFieldCodec (Some None)) |> toEqual jsonNullField
-          );
-          test "null decoding" (fun () =>
-            expect (C.decodeJson optionalNullableFieldCodec jsonNullField) |> toEqual (Js.Result.Ok (Some None))
-          );
-          test "non-null encoding" (fun () =>
-            expect (C.encodeJson spaces::0 optionalNullableFieldCodec (Some (Some "bar"))) |> toEqual jsonSingleStringFieldObject
-          );
-          test "non-null decoding" (fun () =>
-            expect (C.decodeJson optionalNullableFieldCodec jsonSingleStringFieldObject) |> toEqual (Js.Result.Ok (Some (Some "bar")))
+          test("decoding failure", () =>
+            expect(C.decodeJson(C.string, "0.5"))
+            |> toEqual(Js.Result.Error("Expected string"))
           );
         });
-
-        describe "flattened optional nullable field" (fun () => {
-          test "empty encoding" (fun () =>
-            expect (C.encodeJson spaces::0 flattenedFieldCodec None) |> toEqual jsonNullField
+        describe("bool", () => {
+          test("encoding", () =>
+            expect(C.encodeJson(C.bool, true)) |> toEqual("true")
           );
-          test "empty decoding, missing field" (fun () =>
-            expect (C.decodeJson flattenedFieldCodec jsonEmptyObject) |> toEqual (Js.Result.Ok None)
+          test("decoding success", () =>
+            expect(C.decodeJson(C.bool, "false"))
+            |> toEqual(Js.Result.Ok(false))
           );
-          test "empty decoding, null field" (fun () =>
-            expect (C.decodeJson flattenedFieldCodec jsonNullField) |> toEqual (Js.Result.Ok None)
-          );
-          test "non-empty encoding" (fun () =>
-            expect (C.encodeJson spaces::0 flattenedFieldCodec (Some "bar")) |> toEqual jsonSingleStringFieldObject
-          );
-          test "non-empty decoding" (fun () =>
-            expect (C.decodeJson flattenedFieldCodec jsonSingleStringFieldObject) |> toEqual (Js.Result.Ok (Some "bar"))
+          test("decoding failure", () =>
+            expect(C.decodeJson(C.bool, jsonString))
+            |> toEqual(Js.Result.Error("Expected boolean"))
           );
         });
-      });
-
-      describe "recursion" (fun () => {
-        let intTree = Branch (Branch (Leaf 1) (Leaf 2)) (Leaf 3);
-
-        let intTreeJson = formatJsonString {js|{"left": {"left": 1, "right": 2}, "right": 3}|js};
-
-        let treeToXor = fun
-        | Leaf x => C.Xor.left x
-        | Branch l r  => C.Xor.right (l, r);
-
-        let xorToTree = fun
-        | C.Xor.Left x => Leaf x
-        | C.Xor.Right (l, r) => Branch l r;
-
-        let codec = JsonCodec.(fix (fun tree =>        
-          xor int (object2 (field "left" tree) (field "right" tree)) |> wrap treeToXor xorToTree
-        ));
-
-        test "encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec intTree) |> toEqual intTreeJson
-        );
-        test "decoding" (fun () =>
-          expect (C.decodeJson codec intTreeJson) |> toEqual (Js.Result.Ok intTree)
-        );
-      });
-
-      describe "constant" (fun () => {
-        describe "constant string" (fun () => {
-          let codec = C.constant C.string "foo";
-
-          test "encoding" (fun () =>
-            expect (C.encodeJson codec "anything") |> toEqual jsonString
+        describe("null", () => {
+          test("encoding", () =>
+            expect(C.encodeJson(C.null, ())) |> toEqual("null")
           );
-          test "decoding success" (fun () =>
-            expect (C.decodeJson codec jsonString) |> toEqual (Js.Result.Ok "foo")
+          test("decoding success", () =>
+            expect(C.decodeJson(C.null, "null")) |> toEqual(Js.Result.Ok())
           );
-          test "decoding failure, wrong value" (fun () =>
-            expect (C.decodeJson codec "\"bar\"") |> toEqual (Js.Result.Error "Expected constant value \"foo\"")
-          );
-          test "decoding failure, wrong type" (fun () =>
-            expect (C.decodeJson codec jsonNumberArray) |> toEqual (Js.Result.Error "Expected string")
+          test("decoding failure", () =>
+            expect(C.decodeJson(C.null, "true"))
+            |> toEqual(Js.Result.Error("Expected null"))
           );
         });
-        describe "constant field value" (fun () => {
-          let fieldCodec = C.field "type" (C.constant C.string "X");
-          let objectCodec = C.object1 fieldCodec;
-          let expectedJson = {js|{"type":"X"}|js};
-
-          test "encoding" (fun () =>
-            expect (C.encodeJson spaces::0 objectCodec "...") |> toEqual expectedJson
+        describe("nullable", () => {
+          test("empty encoding", () =>
+            expect(C.encodeJson(C.nullable(C.string), None))
+            |> toEqual("null")
           );
-          test "decoding" (fun () =>
-            expect (C.decodeJson objectCodec expectedJson) |> toEqual (Js.Result.Ok "X")
+          test("empty decoding success", () =>
+            expect(C.decodeJson(C.nullable(C.string), "null"))
+            |> toEqual(Js.Result.Ok(None))
           );
-        })
-      });
-
-      describe "dict" (fun () => {
-        let codec = C.dict C.int;
-        let emptyDict = Js.Dict.empty ();
-        let emptyDictJson = {js|{}|js};
-        let nonEmptyDict = Js.Dict.fromArray [| ("x", 1), ("y", 2) |];
-        let nonEmptyDictJson = {js|{"x":1,"y":2}|js};
-
-        test "empty encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec emptyDict) |> toEqual emptyDictJson
-        );
-        test "empty decoding" (fun () =>
-          expect (C.decodeJson codec emptyDictJson) |> toEqual (Js.Result.Ok emptyDict)
-        );
-        test "non-empty encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec nonEmptyDict) |> toEqual nonEmptyDictJson
-        );
-        test "non-empty decoding" (fun () =>
-          expect (C.decodeJson codec nonEmptyDictJson) |> toEqual (Js.Result.Ok nonEmptyDict)
-        );
-      });
-
-      describe "list" (fun () => {
-        let codec = C.list C.int;
-        let emptyList = [];
-        let emptyListJson = {js|[]|js};
-        let nonEmptyList = [1, 2, 3];
-        let nonEmptyListJson = {js|[1,2,3]|js};
-
-        test "empty encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec emptyList) |> toEqual emptyListJson
-        );
-        test "empty decoding" (fun () =>
-          expect (C.decodeJson codec emptyListJson) |> toEqual (Js.Result.Ok emptyList)
-        );
-        test "non-empty encoding" (fun () =>
-          expect (C.encodeJson spaces::0 codec nonEmptyList) |> toEqual nonEmptyListJson
-        );
-        test "non-empty decoding" (fun () =>
-          expect (C.decodeJson codec nonEmptyListJson) |> toEqual (Js.Result.Ok nonEmptyList)
-        );
-      });
-    })
+          test("non-empty encoding", () =>
+            expect(C.encodeJson(C.nullable(C.string), Some("foo")))
+            |> toEqual(jsonString)
+          );
+          test("non-empty decoding success", () =>
+            expect(C.decodeJson(C.nullable(C.number), "1.0"))
+            |> toEqual(Js.Result.Ok(Some(1.0)))
+          );
+          test("decoding failure", () =>
+            expect(C.decodeJson(C.nullable(C.string), "1.0"))
+            |> toEqual(Js.Result.Error("Expected string"))
+          );
+        });
+        describe("array", () => {
+          test("empty encoding", () =>
+            expect(C.encodeJson(C.array(C.number), [||])) |> toEqual("[]")
+          );
+          test("empty decoding", () =>
+            expect(C.decodeJson(C.array(C.string), "[]"))
+            |> toEqual(Js.Result.Ok([||]))
+          );
+          test("non-empty encoding", () =>
+            expect(
+              C.encodeJson(C.array(C.number), [|1.1, 2.2|])
+              |> formatJsonString,
+            )
+            |> toEqual(jsonNumberArray)
+          );
+          test("non-empty decoding success", () =>
+            expect(C.decodeJson(C.array(C.number), jsonNumberArray))
+            |> toEqual(Js.Result.Ok([|1.1, 2.2|]))
+          );
+          test("decoding failure", () =>
+            expect(C.decodeJson(C.array(C.string), "true"))
+            |> toEqual(Js.Result.Error("Expected array"))
+          );
+          test("element decoding failure", () =>
+            expect(C.decodeJson(C.array(C.string), jsonNumberArray))
+            |> toEqual(Js.Result.Error("Expected string"))
+          );
+        });
+        describe("object0", () => {
+          test("encoding", () =>
+            expect(C.encodeJson(C.object0, ())) |> toEqual("{}")
+          );
+          test("decoding success", () =>
+            expect(C.decodeJson(C.object0, "{}")) |> toEqual(Js.Result.Ok())
+          );
+          test("decoding success, ignoring extra fields", () =>
+            expect(C.decodeJson(C.object0, jsonSingleStringFieldObject))
+            |> toEqual(Js.Result.Ok())
+          );
+          test("decoding failure", () =>
+            expect(C.decodeJson(C.object0, "null"))
+            |> toEqual(Js.Result.Error("Expected object"))
+          );
+        });
+        describe("object1", () => {
+          let codec = C.object1(C.field("foo", C.string));
+          test("encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, "bar"))
+            |> toEqual(jsonSingleStringFieldObject)
+          );
+          test("decoding success", () =>
+            expect(C.decodeJson(codec, jsonSingleStringFieldObject))
+            |> toEqual(Js.Result.Ok("bar"))
+          );
+          test("decoding success, ignoring extra fields", () =>
+            expect(C.decodeJson(codec, jsonTwoFieldObject))
+            |> toEqual(Js.Result.Ok("bar"))
+          );
+          test("decoding failure, not an object", () =>
+            expect(C.decodeJson(codec, "false"))
+            |> toEqual(Js.Result.Error("Expected object"))
+          );
+          test("decoding failure, missing field", () =>
+            expect(C.decodeJson(codec, "{}"))
+            |> toEqual(Js.Result.Error("Field 'foo' not found"))
+          );
+          test("decoding failure, wrong field type", () =>
+            expect(C.decodeJson(codec, jsonSingleNumberFieldObject))
+            |> toEqual(Js.Result.Error("Expected string"))
+          );
+        });
+        describe("object2", () => {
+          let codec =
+            C.object2(C.field("foo", C.string), C.field("baz", C.bool));
+          test("encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, ("bar", true)))
+            |> toEqual(jsonTwoFieldObject)
+          );
+          test("decoding success", () =>
+            expect(C.decodeJson(codec, jsonTwoFieldObject))
+            |> toEqual(Js.Result.Ok(("bar", true)))
+          );
+          test("decoding success, ignoring extra fields", () =>
+            expect(C.decodeJson(codec, jsonThreeFieldObject))
+            |> toEqual(Js.Result.Ok(("bar", true)))
+          );
+          test("decoding failure, not an object", () =>
+            expect(C.decodeJson(codec, "7.77"))
+            |> toEqual(Js.Result.Error("Expected object"))
+          );
+          test("decoding failure, missing field", () =>
+            expect(C.decodeJson(codec, jsonSingleStringFieldObject))
+            |> toEqual(Js.Result.Error("Field 'baz' not found"))
+          );
+          test("decoding failure, wrong field type", () =>
+            expect(C.decodeJson(codec, jsonSingleNumberFieldObject))
+            |> toEqual(Js.Result.Error("Expected string"))
+          );
+        });
+        describe("object3", () => {
+          let codec =
+            C.object3(
+              C.field("foo", C.string),
+              C.field("baz", C.bool),
+              C.field("qux", C.number),
+            );
+          test("encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, ("bar", true, 56.78)))
+            |> toEqual(jsonThreeFieldObject)
+          );
+          test("decoding success", () =>
+            expect(C.decodeJson(codec, jsonThreeFieldObject))
+            |> toEqual(Js.Result.Ok(("bar", true, 56.78)))
+          );
+          test("decoding success, ignoring extra fields", () =>
+            expect(C.decodeJson(codec, jsonFourFieldObject))
+            |> toEqual(Js.Result.Ok(("bar", true, 56.78)))
+          );
+          test("decoding failure, not an object", () =>
+            expect(C.decodeJson(codec, "null"))
+            |> toEqual(Js.Result.Error("Expected object"))
+          );
+          test("decoding failure, missing field", () =>
+            expect(C.decodeJson(codec, jsonTwoFieldObject))
+            |> toEqual(Js.Result.Error("Field 'qux' not found"))
+          );
+          test("decoding failure, wrong field type", () =>
+            expect(C.decodeJson(codec, jsonSingleNumberFieldObject))
+            |> toEqual(Js.Result.Error("Expected string"))
+          );
+        });
+        describe("object4", () => {
+          let codec =
+            C.object4(
+              C.field("foo", C.string),
+              C.field("baz", C.bool),
+              C.field("qux", C.number),
+              C.field("quux", C.null),
+            );
+          test("encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, ("bar", true, 56.78, ())))
+            |> toEqual(jsonFourFieldObject)
+          );
+          test("decoding", () =>
+            expect(C.decodeJson(codec, jsonFourFieldObject))
+            |> toEqual(Js.Result.Ok(("bar", true, 56.78, ())))
+          );
+        });
+        describe("object5", () => {
+          let json =
+            formatJsonString(
+              {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5}|js},
+            );
+          let codec =
+            C.object5(
+              C.field("f1", C.int),
+              C.field("f2", C.int),
+              C.field("f3", C.int),
+              C.field("f4", C.int),
+              C.field("f5", C.int),
+            );
+          test("encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, (1, 2, 3, 4, 5)))
+            |> toEqual(json)
+          );
+          test("decoding", () =>
+            expect(C.decodeJson(codec, json))
+            |> toEqual(Js.Result.Ok((1, 2, 3, 4, 5)))
+          );
+        });
+        describe("object6", () => {
+          let json =
+            formatJsonString(
+              {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5, "f6": 6}|js},
+            );
+          let codec =
+            C.object6(
+              C.field("f1", C.int),
+              C.field("f2", C.int),
+              C.field("f3", C.int),
+              C.field("f4", C.int),
+              C.field("f5", C.int),
+              C.field("f6", C.int),
+            );
+          test("encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, (1, 2, 3, 4, 5, 6)))
+            |> toEqual(json)
+          );
+          test("decoding", () =>
+            expect(C.decodeJson(codec, json))
+            |> toEqual(Js.Result.Ok((1, 2, 3, 4, 5, 6)))
+          );
+        });
+        describe("object7", () => {
+          let json =
+            formatJsonString(
+              {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5, "f6": 6, "f7": 7}|js},
+            );
+          let codec =
+            C.object7(
+              C.field("f1", C.int),
+              C.field("f2", C.int),
+              C.field("f3", C.int),
+              C.field("f4", C.int),
+              C.field("f5", C.int),
+              C.field("f6", C.int),
+              C.field("f7", C.int),
+            );
+          test("encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, (1, 2, 3, 4, 5, 6, 7)))
+            |> toEqual(json)
+          );
+          test("decoding", () =>
+            expect(C.decodeJson(codec, json))
+            |> toEqual(Js.Result.Ok((1, 2, 3, 4, 5, 6, 7)))
+          );
+        });
+        describe("object8", () => {
+          let json =
+            formatJsonString(
+              {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5, "f6": 6, "f7": 7, "f8": 8}|js},
+            );
+          let codec =
+            C.object8(
+              C.field("f1", C.int),
+              C.field("f2", C.int),
+              C.field("f3", C.int),
+              C.field("f4", C.int),
+              C.field("f5", C.int),
+              C.field("f6", C.int),
+              C.field("f7", C.int),
+              C.field("f8", C.int),
+            );
+          test("encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, (1, 2, 3, 4, 5, 6, 7, 8)))
+            |> toEqual(json)
+          );
+          test("decoding", () =>
+            expect(C.decodeJson(codec, json))
+            |> toEqual(Js.Result.Ok((1, 2, 3, 4, 5, 6, 7, 8)))
+          );
+        });
+        describe("object9", () => {
+          let json =
+            formatJsonString(
+              {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5, "f6": 6, "f7": 7, "f8": 8, "f9": 9}|js},
+            );
+          let codec =
+            C.object9(
+              C.field("f1", C.int),
+              C.field("f2", C.int),
+              C.field("f3", C.int),
+              C.field("f4", C.int),
+              C.field("f5", C.int),
+              C.field("f6", C.int),
+              C.field("f7", C.int),
+              C.field("f8", C.int),
+              C.field("f9", C.int),
+            );
+          test("encoding", () =>
+            expect(
+              C.encodeJson(~spaces=0, codec, (1, 2, 3, 4, 5, 6, 7, 8, 9)),
+            )
+            |> toEqual(json)
+          );
+          test("decoding", () =>
+            expect(C.decodeJson(codec, json))
+            |> toEqual(Js.Result.Ok((1, 2, 3, 4, 5, 6, 7, 8, 9)))
+          );
+        });
+        describe("object10", () => {
+          let json =
+            formatJsonString(
+              {js|{"f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5, "f6": 6, "f7": 7, "f8": 8, "f9": 9, "f10": 10}|js},
+            );
+          let codec =
+            C.object10(
+              C.field("f1", C.int),
+              C.field("f2", C.int),
+              C.field("f3", C.int),
+              C.field("f4", C.int),
+              C.field("f5", C.int),
+              C.field("f6", C.int),
+              C.field("f7", C.int),
+              C.field("f8", C.int),
+              C.field("f9", C.int),
+              C.field("f10", C.int),
+            );
+          test("encoding", () =>
+            expect(
+              C.encodeJson(
+                ~spaces=0,
+                codec,
+                (1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+              ),
+            )
+            |> toEqual(json)
+          );
+          test("decoding", () =>
+            expect(C.decodeJson(codec, json))
+            |> toEqual(Js.Result.Ok((1, 2, 3, 4, 5, 6, 7, 8, 9, 10)))
+          );
+        });
+        describe("optional and nullable fields", () => {
+          let nullableFieldCodec =
+            C.(object1(field("foo", nullable(string))));
+          let optionalFieldCodec = C.(object1(optional("foo", string)));
+          let optionalNullableFieldCodec =
+            C.(object1(optional("foo", nullable(string))));
+          let flattenedFieldCodec =
+            C.(object1(C.optionalNullable("foo", string)));
+          let jsonNullField = formatJsonString("{\"foo\": null}");
+          describe("nullable field", () => {
+            test("empty encoding", () =>
+              expect(C.encodeJson(~spaces=0, nullableFieldCodec, None))
+              |> toEqual(jsonNullField)
+            );
+            test("empty decoding", () =>
+              expect(C.decodeJson(nullableFieldCodec, jsonNullField))
+              |> toEqual(Js.Result.Ok(None))
+            );
+            test("non-empty encoding", () =>
+              expect(
+                C.encodeJson(~spaces=0, nullableFieldCodec, Some("bar")),
+              )
+              |> toEqual(jsonSingleStringFieldObject)
+            );
+            test("non-empty decoding", () =>
+              expect(
+                C.decodeJson(nullableFieldCodec, jsonSingleStringFieldObject),
+              )
+              |> toEqual(Js.Result.Ok(Some("bar")))
+            );
+          });
+          describe("optional field", () => {
+            test("empty encoding", () =>
+              expect(C.encodeJson(optionalFieldCodec, None))
+              |> toEqual(jsonEmptyObject)
+            );
+            test("empty decoding", () =>
+              expect(C.decodeJson(optionalFieldCodec, jsonEmptyObject))
+              |> toEqual(Js.Result.Ok(None))
+            );
+            test("non-empty encoding", () =>
+              expect(
+                C.encodeJson(~spaces=0, optionalFieldCodec, Some("bar")),
+              )
+              |> toEqual(jsonSingleStringFieldObject)
+            );
+            test("non-empty decoding success", () =>
+              expect(
+                C.decodeJson(optionalFieldCodec, jsonSingleStringFieldObject),
+              )
+              |> toEqual(Js.Result.Ok(Some("bar")))
+            );
+            test("non-empty decoding failure", () =>
+              expect(
+                C.decodeJson(optionalFieldCodec, jsonSingleNumberFieldObject),
+              )
+              |> toEqual(Js.Result.Error("Expected string"))
+            );
+          });
+          describe("optional nullable field", () => {
+            test("empty encoding", () =>
+              expect(C.encodeJson(optionalNullableFieldCodec, None))
+              |> toEqual(jsonEmptyObject)
+            );
+            test("empty decoding", () =>
+              expect(
+                C.decodeJson(optionalNullableFieldCodec, jsonEmptyObject),
+              )
+              |> toEqual(Js.Result.Ok(None))
+            );
+            test("null encoding", () =>
+              expect(
+                C.encodeJson(
+                  ~spaces=0,
+                  optionalNullableFieldCodec,
+                  Some(None),
+                ),
+              )
+              |> toEqual(jsonNullField)
+            );
+            test("null decoding", () =>
+              expect(C.decodeJson(optionalNullableFieldCodec, jsonNullField))
+              |> toEqual(Js.Result.Ok(Some(None)))
+            );
+            test("non-null encoding", () =>
+              expect(
+                C.encodeJson(
+                  ~spaces=0,
+                  optionalNullableFieldCodec,
+                  Some(Some("bar")),
+                ),
+              )
+              |> toEqual(jsonSingleStringFieldObject)
+            );
+            test("non-null decoding", () =>
+              expect(
+                C.decodeJson(
+                  optionalNullableFieldCodec,
+                  jsonSingleStringFieldObject,
+                ),
+              )
+              |> toEqual(Js.Result.Ok(Some(Some("bar"))))
+            );
+          });
+          describe("flattened optional nullable field", () => {
+            test("empty encoding", () =>
+              expect(C.encodeJson(~spaces=0, flattenedFieldCodec, None))
+              |> toEqual(jsonNullField)
+            );
+            test("empty decoding, missing field", () =>
+              expect(C.decodeJson(flattenedFieldCodec, jsonEmptyObject))
+              |> toEqual(Js.Result.Ok(None))
+            );
+            test("empty decoding, null field", () =>
+              expect(C.decodeJson(flattenedFieldCodec, jsonNullField))
+              |> toEqual(Js.Result.Ok(None))
+            );
+            test("non-empty encoding", () =>
+              expect(
+                C.encodeJson(~spaces=0, flattenedFieldCodec, Some("bar")),
+              )
+              |> toEqual(jsonSingleStringFieldObject)
+            );
+            test("non-empty decoding", () =>
+              expect(
+                C.decodeJson(
+                  flattenedFieldCodec,
+                  jsonSingleStringFieldObject,
+                ),
+              )
+              |> toEqual(Js.Result.Ok(Some("bar")))
+            );
+          });
+        });
+        describe("recursion", () => {
+          let intTree = Branch(Branch(Leaf(1), Leaf(2)), Leaf(3));
+          let intTreeJson =
+            formatJsonString(
+              {js|{"left": {"left": 1, "right": 2}, "right": 3}|js},
+            );
+          let treeToXor =
+            fun
+            | Leaf(x) => C.Xor.left(x)
+            | Branch(l, r) => C.Xor.right((l, r));
+          let xorToTree =
+            fun
+            | C.Xor.Left(x) => Leaf(x)
+            | C.Xor.Right((l, r)) => Branch(l, r);
+          let codec =
+            JsonCodec.(
+              fix(tree =>
+                xor(
+                  int,
+                  object2(field("left", tree), field("right", tree)),
+                )
+                |> wrap(treeToXor, xorToTree)
+              )
+            );
+          test("encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, intTree))
+            |> toEqual(intTreeJson)
+          );
+          test("decoding", () =>
+            expect(C.decodeJson(codec, intTreeJson))
+            |> toEqual(Js.Result.Ok(intTree))
+          );
+        });
+        describe("constant", () => {
+          describe("constant string", () => {
+            let codec = C.constant(C.string, "foo");
+            test("encoding", () =>
+              expect(C.encodeJson(codec, "anything")) |> toEqual(jsonString)
+            );
+            test("decoding success", () =>
+              expect(C.decodeJson(codec, jsonString))
+              |> toEqual(Js.Result.Ok("foo"))
+            );
+            test("decoding failure, wrong value", () =>
+              expect(C.decodeJson(codec, "\"bar\""))
+              |> toEqual(Js.Result.Error("Expected constant value \"foo\""))
+            );
+            test("decoding failure, wrong type", () =>
+              expect(C.decodeJson(codec, jsonNumberArray))
+              |> toEqual(Js.Result.Error("Expected string"))
+            );
+          });
+          describe("constant field value", () => {
+            let fieldCodec = C.field("type", C.constant(C.string, "X"));
+            let objectCodec = C.object1(fieldCodec);
+            let expectedJson = {js|{"type":"X"}|js};
+            test("encoding", () =>
+              expect(C.encodeJson(~spaces=0, objectCodec, "..."))
+              |> toEqual(expectedJson)
+            );
+            test("decoding", () =>
+              expect(C.decodeJson(objectCodec, expectedJson))
+              |> toEqual(Js.Result.Ok("X"))
+            );
+          });
+        });
+        describe("dict", () => {
+          let codec = C.dict(C.int);
+          let emptyDict = Js.Dict.empty();
+          let emptyDictJson = {js|{}|js};
+          let nonEmptyDict = Js.Dict.fromArray([|("x", 1), ("y", 2)|]);
+          let nonEmptyDictJson = {js|{"x":1,"y":2}|js};
+          test("empty encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, emptyDict))
+            |> toEqual(emptyDictJson)
+          );
+          test("empty decoding", () =>
+            expect(C.decodeJson(codec, emptyDictJson))
+            |> toEqual(Js.Result.Ok(emptyDict))
+          );
+          test("non-empty encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, nonEmptyDict))
+            |> toEqual(nonEmptyDictJson)
+          );
+          test("non-empty decoding", () =>
+            expect(C.decodeJson(codec, nonEmptyDictJson))
+            |> toEqual(Js.Result.Ok(nonEmptyDict))
+          );
+        });
+        describe("list", () => {
+          let codec = C.list(C.int);
+          let emptyList = [];
+          let emptyListJson = {js|[]|js};
+          let nonEmptyList = [1, 2, 3];
+          let nonEmptyListJson = {js|[1,2,3]|js};
+          test("empty encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, emptyList))
+            |> toEqual(emptyListJson)
+          );
+          test("empty decoding", () =>
+            expect(C.decodeJson(codec, emptyListJson))
+            |> toEqual(Js.Result.Ok(emptyList))
+          );
+          test("non-empty encoding", () =>
+            expect(C.encodeJson(~spaces=0, codec, nonEmptyList))
+            |> toEqual(nonEmptyListJson)
+          );
+          test("non-empty decoding", () =>
+            expect(C.decodeJson(codec, nonEmptyListJson))
+            |> toEqual(Js.Result.Ok(nonEmptyList))
+          );
+        });
+      }
+    ),
+  );

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -9,6 +9,7 @@
       "type": "dev"
     }
   ],
+  "refmt": 3,
   "bs-dev-dependencies": [
     "bs-jest"
   ]

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "bs-jest": "^0.1.0",
-    "bs-platform": "1.9.1",
+    "bs-platform": "2.2.3",
     "jest-cli": "^20.0.4"
   }
 }

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -21,36 +21,37 @@ function generateObjectCodec(n) {
     let typeVariable = i => `'${letters[i]}`;
 
     // start of declaration
-    let code = [`let object${n}`];
+    let code = [`let object${n} = (`];
 
     // arguments
-    numbers.forEach(i => code.push(`((enc${i}, dec${i}): JsonCodec_core.FieldCodec.t ${typeVariable(i)})`));
+    numbers.forEach(i => code.push(
+        `(enc${i}, dec${i}): JsonCodec_core.FieldCodec.t(${typeVariable(i)}),`));
 
     // return type
-    code.push(":JsonCodec_core.Codec.t (");
+    code.push("): JsonCodec_core.Codec.t((");
     code.push(numbers.map(typeVariable).join(", "));
-    code.push(")");
+    code.push("))");
 
     // body start
     code.push("=> {");
 
     // encoder declaration
-    code.push("let encode (");
+    code.push("let encode = ((");
     code.push(numbers.map(i => `v${i}`).join(", "));
-    code.push(") => Js.Json.object_ @@ JsonCodec_util.buildDict [");
-    code.push(numbers.map(i => `enc${i} v${i}`).join(", "));
-    code.push("];");
+    code.push(")) => Js.Json.object_ @@ JsonCodec_util.buildDict([");
+    code.push(numbers.map(i => `enc${i}(v${i})`).join(", "));
+    code.push("]);");
 
     // decoder declaration
-    code.push("let decode json => JsonCodec_util.decodeRawObject json >>=");
-    code.push(`fun dict => dec1 dict`);
+    code.push("let decode = json => JsonCodec_util.decodeRawObject(json) >>=");
+    code.push(`dict => dec1(dict)`);
     for (let i = 1; i < n; i++) {
-        code.push(`>>= fun v${i} => dec${i + 1} dict`);
+        code.push(`>>= v${i} => dec${i + 1}(dict)`);
     }
     if (n > 1) {
-        code.push(`>>= fun v${n} => Js.Result.Ok (`);
+        code.push(`>>= v${n} => Js.Result.Ok((`);
         code.push(numbers.map(i => `v${i}`).join(", "));
-        code.push(")");
+        code.push("))");
     }
     code.push(";");
 

--- a/src/jsonCodec.re
+++ b/src/jsonCodec.re
@@ -16,120 +16,139 @@ module Xor = JsonCodec_xor;
 
 open Result.Ops;
 
-let wrap (f: 'b => 'a) (g: 'a => 'b) ((enc, dec): GenericCodec.t 'a 'c 'd) :GenericCodec.t 'b 'c 'd => (
+let wrap =
+    (f: 'b => 'a, g: 'a => 'b, (enc, dec): GenericCodec.t('a, 'c, 'd))
+    : GenericCodec.t('b, 'c, 'd) => (
   f >>> enc,
-  dec >>> Result.map g
+  dec >>> Result.map(g),
 );
 
-let validate
-    (f: 'a => Decoder.result 'a)
-    ((enc, dec): GenericCodec.t 'a 'c 'd)
-    :GenericCodec.t 'b 'c 'd => (
+let validate =
+    (f: 'a => Decoder.result('a), (enc, dec): GenericCodec.t('a, 'c, 'd))
+    : GenericCodec.t('b, 'c, 'd) => (
   enc,
-  fun x => dec x >>= f
+  x => dec(x) >>= f,
 );
 
-let constant ((enc, dec): GenericCodec.t 'a 'c 'd) (value: 'a) :GenericCodec.t 'a 'c 'd => {
+let constant =
+    ((enc, dec): GenericCodec.t('a, 'c, 'd), value: 'a)
+    : GenericCodec.t('a, 'c, 'd) => {
   let checkValue =
     fun
-    | v when v == value => Result.Ok v
-    | _ => Result.Error ("Expected constant value " ^ encodeJson spaces::0 (enc, dec) value);
-  validate checkValue (Function.const (enc value), dec)
+    | v when v == value => Result.Ok(v)
+    | _ =>
+      Result.Error(
+        "Expected constant value "
+        ++ encodeJson(~spaces=0, (enc, dec), value),
+      );
+  validate(checkValue, (Function.const(enc(value)), dec));
 };
 
-let number: Codec.t float = (Json.number, Util.decodeRawNumber);
+let number: Codec.t(float) = (Json.number, Util.decodeRawNumber);
 
-let int: Codec.t int = number |> validate Util.validInt |> wrap float_of_int int_of_float;
+let int: Codec.t(int) =
+  number |> validate(Util.validInt) |> wrap(float_of_int, int_of_float);
 
-let bool: Codec.t bool =
-  (Json.boolean, Util.decodeRawBool) |> wrap Js.Boolean.to_js_boolean Js.to_bool;
+let bool: Codec.t(bool) =
+  (Json.boolean, Util.decodeRawBool)
+  |> wrap(Js.Boolean.to_js_boolean, Js.to_bool);
 
-let string: Codec.t string = (Json.string, Util.decodeRawString);
+let string: Codec.t(string) = (Json.string, Util.decodeRawString);
 
-let null: Codec.t unit = (
-  Function.const Json.null,
-  Util.decodeRawNull >>> Result.map (Function.const ())
+let null: Codec.t(unit) = (
+  Function.const(Json.null),
+  Util.decodeRawNull >>> Result.map(Function.const()),
 );
 
-let xor ((enc1, dec1): Codec.t 'a) ((enc2, dec2): Codec.t 'b) :Codec.t (Xor.t 'a 'b) => (
-  Xor.either enc1 enc2,
-  fun x =>
-    switch (dec1 x) {
-    | Result.Ok y => Result.Ok (Xor.left y)
-    | Result.Error _ => Result.map Xor.right (dec2 x)
-    }
+let xor =
+    ((enc1, dec1): Codec.t('a), (enc2, dec2): Codec.t('b))
+    : Codec.t(Xor.t('a, 'b)) => (
+  Xor.either(enc1, enc2),
+  x =>
+    switch (dec1(x)) {
+    | Result.Ok(y) => Result.Ok(Xor.left(y))
+    | Result.Error(_) => Result.map(Xor.right, dec2(x))
+    },
 );
 
-let nullable (codec: Codec.t 'a) :Codec.t (option 'a) =>
-  xor null codec |> wrap Xor.fromOption Xor.toOption;
+let nullable = (codec: Codec.t('a)) : Codec.t(option('a)) =>
+  xor(null, codec) |> wrap(Xor.fromOption, Xor.toOption);
 
-let array ((enc, dec): Codec.t 'a) :Codec.t (Js.Array.t 'a) => {
-  let encode value => Json.array (Js.Array.map enc value);
-  let decode json => Util.decodeRawArray json >>= Util.decodeArrayElements dec;
-  (encode, decode)
+let array = ((enc, dec): Codec.t('a)) : Codec.t(Js.Array.t('a)) => {
+  let encode = value => Json.array(Js.Array.map(enc, value));
+  let decode = json =>
+    Util.decodeRawArray(json) >>= Util.decodeArrayElements(dec);
+  (encode, decode);
 };
 
-let list (codec: Codec.t 'a) :Codec.t (list 'a) => wrap Array.of_list Array.to_list (array codec);
+let list = (codec: Codec.t('a)) : Codec.t(list('a)) =>
+  wrap(Array.of_list, Array.to_list, array(codec));
 
-let dict ((enc, dec): Codec.t 'a) :Codec.t (Dict.t 'a) => {
-  let encode dict => Json.object_ (Dict.map ((fun x => enc x) [@bs]) dict);
-  let decode json =>
-    Util.decodeRawObject json >>= (
-      fun obj => {
-        let keys = Dict.keys obj;
-        let length = Array.length keys;
-        let dict = Dict.empty ();
-        let rec loop i =>
+let dict = ((enc, dec): Codec.t('a)) : Codec.t(Dict.t('a)) => {
+  let encode = dict => Json.object_(Dict.map((. x) => enc(x), dict));
+  let decode = json =>
+    Util.decodeRawObject(json)
+    >>= (
+      obj => {
+        let keys = Dict.keys(obj);
+        let length = Array.length(keys);
+        let dict = Dict.empty();
+        let rec loop = i =>
           if (i < length) {
-            let k = keys.(i);
-            dec (Dict.unsafeGet obj k) >>= (
-              fun decoded => {
-                Dict.set dict k decoded;
-                loop (i + 1)
+            let k = keys[i];
+            dec(Dict.unsafeGet(obj, k))
+            >>= (
+              decoded => {
+                Dict.set(dict, k, decoded);
+                loop(i + 1);
               }
-            )
+            );
           } else {
-            Result.Ok dict
+            Result.Ok(dict);
           };
-        loop 0
+        loop(0);
       }
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let fix (f: Codec.t 'a => Codec.t 'a) :Codec.t 'a => {
-  let encoderRef: ref (option (JsonEncoder.t 'a)) = ref None;
-  let decoderRef: ref (option (JsonDecoder.t 'a)) = ref None;
-  let emptyCodec: Codec.t 'a = (
-    fun value => Option.getExn !encoderRef @@ value,
-    fun json => Option.getExn !decoderRef @@ json
+let fix = (f: Codec.t('a) => Codec.t('a)) : Codec.t('a) => {
+  let encoderRef: ref(option(JsonEncoder.t('a))) = ref(None);
+  let decoderRef: ref(option(JsonDecoder.t('a))) = ref(None);
+  let emptyCodec: Codec.t('a) = (
+    value => Option.getExn(encoderRef^) @@ value,
+    json => Option.getExn(decoderRef^) @@ json,
   );
-  let (encode, decode) = f emptyCodec;
-  encoderRef := Some encode;
-  decoderRef := Some decode;
-  (encode, decode)
+  let (encode, decode) = f(emptyCodec);
+  encoderRef := Some(encode);
+  decoderRef := Some(decode);
+  (encode, decode);
 };
 
-let field (name: Dict.key) ((enc, dec): Codec.t 'a) :FieldCodec.t 'a => (
-  fun value => Some (name, enc value),
-  Util.decodeMandatoryField dec name
+let field = (name: Dict.key, (enc, dec): Codec.t('a)) : FieldCodec.t('a) => (
+  value => Some((name, enc(value))),
+  Util.decodeMandatoryField(dec, name),
 );
 
-let optional (name: Dict.key) ((enc, dec): Codec.t 'a) :FieldCodec.t (option 'a) => (
-  Option.map ((fun value => (name, enc value)) [@bs]),
-  Util.decodeOptionalField dec name
+let optional =
+    (name: Dict.key, (enc, dec): Codec.t('a))
+    : FieldCodec.t(option('a)) => (
+  Option.map((. value) => (name, enc(value))),
+  Util.decodeOptionalField(dec, name),
 );
 
-let optionalNullable (name: Dict.key) (codec: Codec.t 'a) :FieldCodec.t (option 'a) => {
+let optionalNullable =
+    (name: Dict.key, codec: Codec.t('a))
+    : FieldCodec.t(option('a)) => {
   let flatten =
     fun
-    | Some (Some x) => Some x
-    | Some None
+    | Some(Some(x)) => Some(x)
+    | Some(None)
     | None => None;
-  optional name (nullable codec) |> wrap Option.some flatten
+  optional(name, nullable(codec)) |> wrap(Option.some, flatten);
 };
 
-let object0: Codec.t unit = (
-  Function.const (Json.object_ (Dict.empty ())),
-  Util.decodeRawObject >>> Result.map (Function.const ())
+let object0: Codec.t(unit) = (
+  Function.const(Json.object_(Dict.empty())),
+  Util.decodeRawObject >>> Result.map(Function.const()),
 );

--- a/src/jsonCodec_core.re
+++ b/src/jsonCodec_core.re
@@ -5,48 +5,49 @@ module Util = JsonCodec_util;
 open Result.Ops;
 
 module Encoder = {
-  type t 'a 'b = 'a => 'b;
+  type t('a, 'b) = 'a => 'b;
 };
 
 module Decoder = {
   type error = string;
-  type result 'a = Result.t 'a error;
-  type t 'a 'b = 'b => result 'a;
+  type result('a) = Result.t('a, error);
+  type t('a, 'b) = 'b => result('a);
 };
 
 module JsonEncoder = {
-  type t 'a = Encoder.t 'a Js.Json.t;
+  type t('a) = Encoder.t('a, Js.Json.t);
 };
 
 module JsonDecoder = {
-  type t 'a = Decoder.t 'a Js.Json.t;
+  type t('a) = Decoder.t('a, Js.Json.t);
 };
 
 module Codec = {
-  type t 'a = (JsonEncoder.t 'a, JsonDecoder.t 'a);
+  type t('a) = (JsonEncoder.t('a), JsonDecoder.t('a));
 };
 
 module GenericCodec = {
-  type t 'a 'b 'c = (Encoder.t 'a 'b, Decoder.t 'a 'c);
+  type t('a, 'b, 'c) = (Encoder.t('a, 'b), Decoder.t('a, 'c));
 };
 
 module FieldEncoder = {
-  type t 'a = Encoder.t 'a (option (Js.Dict.key, Js.Json.t));
+  type t('a) = Encoder.t('a, option((Js.Dict.key, Js.Json.t)));
 };
 
 module FieldDecoder = {
-  type dict = Js.Dict.t Js.Json.t;
-  type t 'a = Decoder.t 'a dict;
+  type dict = Js.Dict.t(Js.Json.t);
+  type t('a) = Decoder.t('a, dict);
 };
 
 module FieldCodec = {
-  type t 'a = (FieldEncoder.t 'a, FieldDecoder.t 'a);
+  type t('a) = (FieldEncoder.t('a), FieldDecoder.t('a));
 };
 
-let encode ((enc, _): Codec.t 'a) x => enc x;
+let encode = ((enc, _): Codec.t('a), x) => enc(x);
 
-let decode ((_, dec): Codec.t 'a) x => dec x;
+let decode = ((_, dec): Codec.t('a), x) => dec(x);
 
-let encodeJson ::spaces=2 codec a => Util.formatJson (encode codec a) spaces;
+let encodeJson = (~spaces=2, codec, a) =>
+  Util.formatJson(encode(codec, a), spaces);
 
-let decodeJson codec s => Util.parseJson s >>= decode codec;
+let decodeJson = (codec, s) => Util.parseJson(s) >>= decode(codec);

--- a/src/jsonCodec_function.re
+++ b/src/jsonCodec_function.re
@@ -1,5 +1,5 @@
-let const x _ => x;
+let const = (x, _) => x;
 
 module Ops = {
-  let (>>>) f g x => g (f x);
+  let (>>>) = (f, g, x) => g(f(x));
 };

--- a/src/jsonCodec_object.re
+++ b/src/jsonCodec_object.re
@@ -1,152 +1,230 @@
 /* This file is auto-generated. Please do not modify it. */
 open JsonCodec_result.Ops;
 
-let object1 ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a) :JsonCodec_core.Codec.t 'a => {
-  let encode v1 => Js.Json.object_ @@ JsonCodec_util.buildDict [enc1 v1];
-  let decode json => JsonCodec_util.decodeRawObject json >>= (fun dict => dec1 dict);
-  (encode, decode)
+let object1 =
+    ((enc1, dec1): JsonCodec_core.FieldCodec.t('a))
+    : JsonCodec_core.Codec.t('a) => {
+  let encode = v1 => Js.Json.object_ @@ JsonCodec_util.buildDict([enc1(v1)]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json) >>= (dict => dec1(dict));
+  (encode, decode);
 };
 
-let object2
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    :JsonCodec_core.Codec.t ('a, 'b) => {
-  let encode (v1, v2) => Js.Json.object_ @@ JsonCodec_util.buildDict [enc1 v1, enc2 v2];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict => dec1 dict >>= (fun v1 => dec2 dict >>= (fun v2 => Js.Result.Ok (v1, v2)))
+let object2 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+    )
+    : JsonCodec_core.Codec.t(('a, 'b)) => {
+  let encode = ((v1, v2)) =>
+    Js.Json.object_ @@ JsonCodec_util.buildDict([enc1(v1), enc2(v2)]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict) >>= (v1 => dec2(dict) >>= (v2 => Js.Result.Ok((v1, v2))))
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object3
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c) => {
-  let encode (v1, v2, v3) =>
-    Js.Json.object_ @@ JsonCodec_util.buildDict [enc1 v1, enc2 v2, enc3 v3];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 => dec2 dict >>= (fun v2 => dec3 dict >>= (fun v3 => Js.Result.Ok (v1, v2, v3)))
+let object3 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+    )
+    : JsonCodec_core.Codec.t(('a, 'b, 'c)) => {
+  let encode = ((v1, v2, v3)) =>
+    Js.Json.object_ @@
+    JsonCodec_util.buildDict([enc1(v1), enc2(v2), enc3(v3)]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (v2 => dec3(dict) >>= (v3 => Js.Result.Ok((v1, v2, v3))))
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object4
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd) => {
-  let encode (v1, v2, v3, v4) =>
-    Js.Json.object_ @@ JsonCodec_util.buildDict [enc1 v1, enc2 v2, enc3 v3, enc4 v4];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (fun v3 => dec4 dict >>= (fun v4 => Js.Result.Ok (v1, v2, v3, v4)))
+let object4 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+    )
+    : JsonCodec_core.Codec.t(('a, 'b, 'c, 'd)) => {
+  let encode = ((v1, v2, v3, v4)) =>
+    Js.Json.object_ @@
+    JsonCodec_util.buildDict([enc1(v1), enc2(v2), enc3(v3), enc4(v4)]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 => dec4(dict) >>= (v4 => Js.Result.Ok((v1, v2, v3, v4)))
+                )
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object5
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e) => {
-  let encode (v1, v2, v3, v4, v5) =>
-    Js.Json.object_ @@ JsonCodec_util.buildDict [enc1 v1, enc2 v2, enc3 v3, enc4 v4, enc5 v5];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 => dec5 dict >>= (fun v5 => Js.Result.Ok (v1, v2, v3, v4, v5))
+let object5 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+    )
+    : JsonCodec_core.Codec.t(('a, 'b, 'c, 'd, 'e)) => {
+  let encode = ((v1, v2, v3, v4, v5)) =>
+    Js.Json.object_ @@
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (v5 => Js.Result.Ok((v1, v2, v3, v4, v5)))
                     )
                 )
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object6
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f) => {
-  let encode (v1, v2, v3, v4, v5, v6) =>
+let object6 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+    )
+    : JsonCodec_core.Codec.t(('a, 'b, 'c, 'd, 'e, 'f)) => {
+  let encode = ((v1, v2, v3, v4, v5, v6)) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [enc1 v1, enc2 v2, enc3 v3, enc4 v4, enc5 v5, enc6 v6];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 => dec6 dict >>= (fun v6 => Js.Result.Ok (v1, v2, v3, v4, v5, v6))
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (v6 => Js.Result.Ok((v1, v2, v3, v4, v5, v6)))
                         )
                     )
                 )
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object7
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7) =>
+let object7 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+    )
+    : JsonCodec_core.Codec.t(('a, 'b, 'c, 'd, 'e, 'f, 'g)) => {
+  let encode = ((v1, v2, v3, v4, v5, v6, v7)) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [enc1 v1, enc2 v2, enc3 v3, enc4 v4, enc5 v5, enc6 v6, enc7 v7];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (fun v7 => Js.Result.Ok (v1, v2, v3, v4, v5, v6, v7))
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    Js.Result.Ok((v1, v2, v3, v4, v5, v6, v7))
+                                )
                             )
                         )
                     )
@@ -154,50 +232,71 @@ let object7
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object8
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8) =>
+let object8 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+    )
+    : JsonCodec_core.Codec.t(('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h)) => {
+  let encode = ((v1, v2, v3, v4, v5, v6, v7, v8)) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 => Js.Result.Ok (v1, v2, v3, v4, v5, v6, v7, v8)
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        Js.Result.Ok((
+                                          v1,
+                                          v2,
+                                          v3,
+                                          v4,
+                                          v5,
+                                          v6,
+                                          v7,
+                                          v8,
+                                        ))
                                     )
                                 )
                             )
@@ -207,55 +306,77 @@ let object8
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object9
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9) =>
+let object9 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+    )
+    : JsonCodec_core.Codec.t(('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i)) => {
+  let encode = ((v1, v2, v3, v4, v5, v6, v7, v8, v9)) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            Js.Result.Ok (v1, v2, v3, v4, v5, v6, v7, v8, v9)
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            Js.Result.Ok((
+                                              v1,
+                                              v2,
+                                              v3,
+                                              v4,
+                                              v5,
+                                              v6,
+                                              v7,
+                                              v8,
+                                              v9,
+                                            ))
                                         )
                                     )
                                 )
@@ -266,59 +387,72 @@ let object9
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object10
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) =>
+let object10 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+    )
+    : JsonCodec_core.Codec.t(('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j)) => {
+  let encode = ((v1, v2, v3, v4, v5, v6, v7, v8, v9, v10)) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                Js.Result.Ok (
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                Js.Result.Ok((
                                                   v1,
                                                   v2,
                                                   v3,
@@ -328,8 +462,8 @@ let object10
                                                   v7,
                                                   v8,
                                                   v9,
-                                                  v10
-                                                )
+                                                  v10,
+                                                ))
                                             )
                                         )
                                     )
@@ -341,63 +475,77 @@ let object10
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object11
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) =>
+let object11 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+    )
+    : JsonCodec_core.Codec.t(('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) => {
+  let encode = ((v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    Js.Result.Ok (
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    Js.Result.Ok((
                                                       v1,
                                                       v2,
                                                       v3,
@@ -408,8 +556,8 @@ let object11
                                                       v8,
                                                       v9,
                                                       v10,
-                                                      v11
-                                                    )
+                                                      v11,
+                                                    ))
                                                 )
                                             )
                                         )
@@ -422,67 +570,84 @@ let object11
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object12
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) =>
+let object12 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+    )
+    : JsonCodec_core.Codec.t(
+        ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l),
+      ) => {
+  let encode = ((v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12)) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        Js.Result.Ok (
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        Js.Result.Ok((
                                                           v1,
                                                           v2,
                                                           v3,
@@ -494,8 +659,8 @@ let object12
                                                           v9,
                                                           v10,
                                                           v11,
-                                                          v12
-                                                        )
+                                                          v12,
+                                                        ))
                                                     )
                                                 )
                                             )
@@ -509,71 +674,89 @@ let object12
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object13
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) =>
+let object13 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+    )
+    : JsonCodec_core.Codec.t(
+        ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm),
+      ) => {
+  let encode = ((v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13)) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            Js.Result.Ok (
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            Js.Result.Ok((
                                                               v1,
                                                               v2,
                                                               v3,
@@ -586,8 +769,8 @@ let object13
                                                               v10,
                                                               v11,
                                                               v12,
-                                                              v13
-                                                            )
+                                                              v13,
+                                                            ))
                                                         )
                                                     )
                                                 )
@@ -602,75 +785,95 @@ let object13
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object14
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) =>
+let object14 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+    )
+    : JsonCodec_core.Codec.t(
+        ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n),
+      ) => {
+  let encode =
+      ((v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14)) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                Js.Result.Ok (
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                Js.Result.Ok((
                                                                   v1,
                                                                   v2,
                                                                   v3,
@@ -684,8 +887,8 @@ let object14
                                                                   v11,
                                                                   v12,
                                                                   v13,
-                                                                  v14
-                                                                )
+                                                                  v14,
+                                                                ))
                                                             )
                                                         )
                                                     )
@@ -701,191 +904,100 @@ let object14
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object15
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) =>
+let object15 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+    )
+    : JsonCodec_core.Codec.t(
+        ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o),
+      ) => {
+  let encode =
+      ((v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15)) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    Js.Result.Ok (
-                                                                    v1,
-                                                                    v2,
-                                                                    v3,
-                                                                    v4,
-                                                                    v5,
-                                                                    v6,
-                                                                    v7,
-                                                                    v8,
-                                                                    v9,
-                                                                    v10,
-                                                                    v11,
-                                                                    v12,
-                                                                    v13,
-                                                                    v14,
-                                                                    v15
-                                                                    )
-                                                                )
-                                                            )
-                                                        )
-                                                    )
-                                                )
-                                            )
-                                        )
-                                    )
-                                )
-                            )
-                        )
-                    )
-                )
-            )
-        )
-    );
-  (encode, decode)
-};
-
-let object16
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) =>
-    Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
-                                                                  v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
-                                                                    v16 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -901,9 +1013,7 @@ let object16
                                                                     v13,
                                                                     v14,
                                                                     v15,
-                                                                    v16
-                                                                    )
-                                                                    )
+                                                                    ))
                                                                 )
                                                             )
                                                         )
@@ -920,90 +1030,126 @@ let object16
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object17
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    ((enc17, dec17): JsonCodec_core.FieldCodec.t 'q)
-    :JsonCodec_core.Codec.t ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p, 'q) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17) =>
+let object16 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+    )
+    : JsonCodec_core.Codec.t(
+        ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p),
+      ) => {
+  let encode =
+      (
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+        ),
+      ) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16,
-      enc17 v17
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v16 =>
-                                                                    dec17 dict >>= (
-                                                                    fun
-                                                                    v17 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -1020,9 +1166,7 @@ let object17
                                                                     v14,
                                                                     v15,
                                                                     v16,
-                                                                    v17
-                                                                    )
-                                                                    )
+                                                                    ))
                                                                     )
                                                                 )
                                                             )
@@ -1040,114 +1184,134 @@ let object17
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object18
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    ((enc17, dec17): JsonCodec_core.FieldCodec.t 'q)
-    ((enc18, dec18): JsonCodec_core.FieldCodec.t 'r)
-    :JsonCodec_core.Codec.t (
-       'a,
-       'b,
-       'c,
-       'd,
-       'e,
-       'f,
-       'g,
-       'h,
-       'i,
-       'j,
-       'k,
-       'l,
-       'm,
-       'n,
-       'o,
-       'p,
-       'q,
-       'r
-     ) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18) =>
+let object17 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+      (enc17, dec17): JsonCodec_core.FieldCodec.t('q),
+    )
+    : JsonCodec_core.Codec.t(
+        ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n, 'o, 'p, 'q),
+      ) => {
+  let encode =
+      (
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+          v17,
+        ),
+      ) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16,
-      enc17 v17,
-      enc18 v18
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+      enc17(v17),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v16 =>
-                                                                    dec17 dict >>= (
-                                                                    fun
+                                                                    dec17(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v17 =>
-                                                                    dec18 dict >>= (
-                                                                    fun
-                                                                    v18 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -1165,9 +1329,7 @@ let object18
                                                                     v15,
                                                                     v16,
                                                                     v17,
-                                                                    v18
-                                                                    )
-                                                                    )
+                                                                    ))
                                                                     )
                                                                     )
                                                                 )
@@ -1186,120 +1348,161 @@ let object18
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object19
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    ((enc17, dec17): JsonCodec_core.FieldCodec.t 'q)
-    ((enc18, dec18): JsonCodec_core.FieldCodec.t 'r)
-    ((enc19, dec19): JsonCodec_core.FieldCodec.t 's)
-    :JsonCodec_core.Codec.t (
-       'a,
-       'b,
-       'c,
-       'd,
-       'e,
-       'f,
-       'g,
-       'h,
-       'i,
-       'j,
-       'k,
-       'l,
-       'm,
-       'n,
-       'o,
-       'p,
-       'q,
-       'r,
-       's
-     ) => {
-  let encode (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19) =>
+let object18 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+      (enc17, dec17): JsonCodec_core.FieldCodec.t('q),
+      (enc18, dec18): JsonCodec_core.FieldCodec.t('r),
+    )
+    : JsonCodec_core.Codec.t(
+        (
+          'a,
+          'b,
+          'c,
+          'd,
+          'e,
+          'f,
+          'g,
+          'h,
+          'i,
+          'j,
+          'k,
+          'l,
+          'm,
+          'n,
+          'o,
+          'p,
+          'q,
+          'r,
+        ),
+      ) => {
+  let encode =
+      (
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+          v17,
+          v18,
+        ),
+      ) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16,
-      enc17 v17,
-      enc18 v18,
-      enc19 v19
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+      enc17(v17),
+      enc18(v18),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v16 =>
-                                                                    dec17 dict >>= (
-                                                                    fun
+                                                                    dec17(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v17 =>
-                                                                    dec18 dict >>= (
-                                                                    fun
+                                                                    dec18(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v18 =>
-                                                                    dec19 dict >>= (
-                                                                    fun
-                                                                    v19 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -1318,9 +1521,7 @@ let object19
                                                                     v16,
                                                                     v17,
                                                                     v18,
-                                                                    v19
-                                                                    )
-                                                                    )
+                                                                    ))
                                                                     )
                                                                     )
                                                                     )
@@ -1340,127 +1541,170 @@ let object19
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object20
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    ((enc17, dec17): JsonCodec_core.FieldCodec.t 'q)
-    ((enc18, dec18): JsonCodec_core.FieldCodec.t 'r)
-    ((enc19, dec19): JsonCodec_core.FieldCodec.t 's)
-    ((enc20, dec20): JsonCodec_core.FieldCodec.t 't)
-    :JsonCodec_core.Codec.t (
-       'a,
-       'b,
-       'c,
-       'd,
-       'e,
-       'f,
-       'g,
-       'h,
-       'i,
-       'j,
-       'k,
-       'l,
-       'm,
-       'n,
-       'o,
-       'p,
-       'q,
-       'r,
-       's,
-       't
-     ) => {
-  let encode
-      (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20) =>
+let object19 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+      (enc17, dec17): JsonCodec_core.FieldCodec.t('q),
+      (enc18, dec18): JsonCodec_core.FieldCodec.t('r),
+      (enc19, dec19): JsonCodec_core.FieldCodec.t('s),
+    )
+    : JsonCodec_core.Codec.t(
+        (
+          'a,
+          'b,
+          'c,
+          'd,
+          'e,
+          'f,
+          'g,
+          'h,
+          'i,
+          'j,
+          'k,
+          'l,
+          'm,
+          'n,
+          'o,
+          'p,
+          'q,
+          'r,
+          's,
+        ),
+      ) => {
+  let encode =
+      (
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+          v17,
+          v18,
+          v19,
+        ),
+      ) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16,
-      enc17 v17,
-      enc18 v18,
-      enc19 v19,
-      enc20 v20
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+      enc17(v17),
+      enc18(v18),
+      enc19(v19),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v16 =>
-                                                                    dec17 dict >>= (
-                                                                    fun
+                                                                    dec17(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v17 =>
-                                                                    dec18 dict >>= (
-                                                                    fun
+                                                                    dec18(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v18 =>
-                                                                    dec19 dict >>= (
-                                                                    fun
+                                                                    dec19(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v19 =>
-                                                                    dec20 dict >>= (
-                                                                    fun
-                                                                    v20 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -1480,9 +1724,7 @@ let object20
                                                                     v17,
                                                                     v18,
                                                                     v19,
-                                                                    v20
-                                                                    )
-                                                                    )
+                                                                    ))
                                                                     )
                                                                     )
                                                                     )
@@ -1503,155 +1745,179 @@ let object20
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object21
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    ((enc17, dec17): JsonCodec_core.FieldCodec.t 'q)
-    ((enc18, dec18): JsonCodec_core.FieldCodec.t 'r)
-    ((enc19, dec19): JsonCodec_core.FieldCodec.t 's)
-    ((enc20, dec20): JsonCodec_core.FieldCodec.t 't)
-    ((enc21, dec21): JsonCodec_core.FieldCodec.t 'u)
-    :JsonCodec_core.Codec.t (
-       'a,
-       'b,
-       'c,
-       'd,
-       'e,
-       'f,
-       'g,
-       'h,
-       'i,
-       'j,
-       'k,
-       'l,
-       'm,
-       'n,
-       'o,
-       'p,
-       'q,
-       'r,
-       's,
-       't,
-       'u
-     ) => {
-  let encode
+let object20 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+      (enc17, dec17): JsonCodec_core.FieldCodec.t('q),
+      (enc18, dec18): JsonCodec_core.FieldCodec.t('r),
+      (enc19, dec19): JsonCodec_core.FieldCodec.t('s),
+      (enc20, dec20): JsonCodec_core.FieldCodec.t('t),
+    )
+    : JsonCodec_core.Codec.t(
+        (
+          'a,
+          'b,
+          'c,
+          'd,
+          'e,
+          'f,
+          'g,
+          'h,
+          'i,
+          'j,
+          'k,
+          'l,
+          'm,
+          'n,
+          'o,
+          'p,
+          'q,
+          'r,
+          's,
+          't,
+        ),
+      ) => {
+  let encode =
       (
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        v16,
-        v17,
-        v18,
-        v19,
-        v20,
-        v21
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+          v17,
+          v18,
+          v19,
+          v20,
+        ),
       ) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16,
-      enc17 v17,
-      enc18 v18,
-      enc19 v19,
-      enc20 v20,
-      enc21 v21
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+      enc17(v17),
+      enc18(v18),
+      enc19(v19),
+      enc20(v20),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v16 =>
-                                                                    dec17 dict >>= (
-                                                                    fun
+                                                                    dec17(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v17 =>
-                                                                    dec18 dict >>= (
-                                                                    fun
+                                                                    dec18(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v18 =>
-                                                                    dec19 dict >>= (
-                                                                    fun
+                                                                    dec19(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v19 =>
-                                                                    dec20 dict >>= (
-                                                                    fun
+                                                                    dec20(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v20 =>
-                                                                    dec21 dict >>= (
-                                                                    fun
-                                                                    v21 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -1672,9 +1938,7 @@ let object21
                                                                     v18,
                                                                     v19,
                                                                     v20,
-                                                                    v21
-                                                                    )
-                                                                    )
+                                                                    ))
                                                                     )
                                                                     )
                                                                     )
@@ -1696,162 +1960,188 @@ let object21
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object22
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    ((enc17, dec17): JsonCodec_core.FieldCodec.t 'q)
-    ((enc18, dec18): JsonCodec_core.FieldCodec.t 'r)
-    ((enc19, dec19): JsonCodec_core.FieldCodec.t 's)
-    ((enc20, dec20): JsonCodec_core.FieldCodec.t 't)
-    ((enc21, dec21): JsonCodec_core.FieldCodec.t 'u)
-    ((enc22, dec22): JsonCodec_core.FieldCodec.t 'v)
-    :JsonCodec_core.Codec.t (
-       'a,
-       'b,
-       'c,
-       'd,
-       'e,
-       'f,
-       'g,
-       'h,
-       'i,
-       'j,
-       'k,
-       'l,
-       'm,
-       'n,
-       'o,
-       'p,
-       'q,
-       'r,
-       's,
-       't,
-       'u,
-       'v
-     ) => {
-  let encode
+let object21 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+      (enc17, dec17): JsonCodec_core.FieldCodec.t('q),
+      (enc18, dec18): JsonCodec_core.FieldCodec.t('r),
+      (enc19, dec19): JsonCodec_core.FieldCodec.t('s),
+      (enc20, dec20): JsonCodec_core.FieldCodec.t('t),
+      (enc21, dec21): JsonCodec_core.FieldCodec.t('u),
+    )
+    : JsonCodec_core.Codec.t(
+        (
+          'a,
+          'b,
+          'c,
+          'd,
+          'e,
+          'f,
+          'g,
+          'h,
+          'i,
+          'j,
+          'k,
+          'l,
+          'm,
+          'n,
+          'o,
+          'p,
+          'q,
+          'r,
+          's,
+          't,
+          'u,
+        ),
+      ) => {
+  let encode =
       (
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        v16,
-        v17,
-        v18,
-        v19,
-        v20,
-        v21,
-        v22
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+          v17,
+          v18,
+          v19,
+          v20,
+          v21,
+        ),
       ) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16,
-      enc17 v17,
-      enc18 v18,
-      enc19 v19,
-      enc20 v20,
-      enc21 v21,
-      enc22 v22
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+      enc17(v17),
+      enc18(v18),
+      enc19(v19),
+      enc20(v20),
+      enc21(v21),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v16 =>
-                                                                    dec17 dict >>= (
-                                                                    fun
+                                                                    dec17(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v17 =>
-                                                                    dec18 dict >>= (
-                                                                    fun
+                                                                    dec18(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v18 =>
-                                                                    dec19 dict >>= (
-                                                                    fun
+                                                                    dec19(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v19 =>
-                                                                    dec20 dict >>= (
-                                                                    fun
+                                                                    dec20(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v20 =>
-                                                                    dec21 dict >>= (
-                                                                    fun
+                                                                    dec21(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v21 =>
-                                                                    dec22 dict >>= (
-                                                                    fun
-                                                                    v22 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -1873,9 +2163,7 @@ let object22
                                                                     v19,
                                                                     v20,
                                                                     v21,
-                                                                    v22
-                                                                    )
-                                                                    )
+                                                                    ))
                                                                     )
                                                                     )
                                                                     )
@@ -1898,169 +2186,197 @@ let object22
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object23
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    ((enc17, dec17): JsonCodec_core.FieldCodec.t 'q)
-    ((enc18, dec18): JsonCodec_core.FieldCodec.t 'r)
-    ((enc19, dec19): JsonCodec_core.FieldCodec.t 's)
-    ((enc20, dec20): JsonCodec_core.FieldCodec.t 't)
-    ((enc21, dec21): JsonCodec_core.FieldCodec.t 'u)
-    ((enc22, dec22): JsonCodec_core.FieldCodec.t 'v)
-    ((enc23, dec23): JsonCodec_core.FieldCodec.t 'w)
-    :JsonCodec_core.Codec.t (
-       'a,
-       'b,
-       'c,
-       'd,
-       'e,
-       'f,
-       'g,
-       'h,
-       'i,
-       'j,
-       'k,
-       'l,
-       'm,
-       'n,
-       'o,
-       'p,
-       'q,
-       'r,
-       's,
-       't,
-       'u,
-       'v,
-       'w
-     ) => {
-  let encode
+let object22 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+      (enc17, dec17): JsonCodec_core.FieldCodec.t('q),
+      (enc18, dec18): JsonCodec_core.FieldCodec.t('r),
+      (enc19, dec19): JsonCodec_core.FieldCodec.t('s),
+      (enc20, dec20): JsonCodec_core.FieldCodec.t('t),
+      (enc21, dec21): JsonCodec_core.FieldCodec.t('u),
+      (enc22, dec22): JsonCodec_core.FieldCodec.t('v),
+    )
+    : JsonCodec_core.Codec.t(
+        (
+          'a,
+          'b,
+          'c,
+          'd,
+          'e,
+          'f,
+          'g,
+          'h,
+          'i,
+          'j,
+          'k,
+          'l,
+          'm,
+          'n,
+          'o,
+          'p,
+          'q,
+          'r,
+          's,
+          't,
+          'u,
+          'v,
+        ),
+      ) => {
+  let encode =
       (
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        v16,
-        v17,
-        v18,
-        v19,
-        v20,
-        v21,
-        v22,
-        v23
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+          v17,
+          v18,
+          v19,
+          v20,
+          v21,
+          v22,
+        ),
       ) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16,
-      enc17 v17,
-      enc18 v18,
-      enc19 v19,
-      enc20 v20,
-      enc21 v21,
-      enc22 v22,
-      enc23 v23
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+      enc17(v17),
+      enc18(v18),
+      enc19(v19),
+      enc20(v20),
+      enc21(v21),
+      enc22(v22),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v16 =>
-                                                                    dec17 dict >>= (
-                                                                    fun
+                                                                    dec17(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v17 =>
-                                                                    dec18 dict >>= (
-                                                                    fun
+                                                                    dec18(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v18 =>
-                                                                    dec19 dict >>= (
-                                                                    fun
+                                                                    dec19(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v19 =>
-                                                                    dec20 dict >>= (
-                                                                    fun
+                                                                    dec20(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v20 =>
-                                                                    dec21 dict >>= (
-                                                                    fun
+                                                                    dec21(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v21 =>
-                                                                    dec22 dict >>= (
-                                                                    fun
+                                                                    dec22(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v22 =>
-                                                                    dec23 dict >>= (
-                                                                    fun
-                                                                    v23 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -2083,9 +2399,7 @@ let object23
                                                                     v20,
                                                                     v21,
                                                                     v22,
-                                                                    v23
-                                                                    )
-                                                                    )
+                                                                    ))
                                                                     )
                                                                     )
                                                                     )
@@ -2109,176 +2423,206 @@ let object23
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object24
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    ((enc17, dec17): JsonCodec_core.FieldCodec.t 'q)
-    ((enc18, dec18): JsonCodec_core.FieldCodec.t 'r)
-    ((enc19, dec19): JsonCodec_core.FieldCodec.t 's)
-    ((enc20, dec20): JsonCodec_core.FieldCodec.t 't)
-    ((enc21, dec21): JsonCodec_core.FieldCodec.t 'u)
-    ((enc22, dec22): JsonCodec_core.FieldCodec.t 'v)
-    ((enc23, dec23): JsonCodec_core.FieldCodec.t 'w)
-    ((enc24, dec24): JsonCodec_core.FieldCodec.t 'x)
-    :JsonCodec_core.Codec.t (
-       'a,
-       'b,
-       'c,
-       'd,
-       'e,
-       'f,
-       'g,
-       'h,
-       'i,
-       'j,
-       'k,
-       'l,
-       'm,
-       'n,
-       'o,
-       'p,
-       'q,
-       'r,
-       's,
-       't,
-       'u,
-       'v,
-       'w,
-       'x
-     ) => {
-  let encode
+let object23 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+      (enc17, dec17): JsonCodec_core.FieldCodec.t('q),
+      (enc18, dec18): JsonCodec_core.FieldCodec.t('r),
+      (enc19, dec19): JsonCodec_core.FieldCodec.t('s),
+      (enc20, dec20): JsonCodec_core.FieldCodec.t('t),
+      (enc21, dec21): JsonCodec_core.FieldCodec.t('u),
+      (enc22, dec22): JsonCodec_core.FieldCodec.t('v),
+      (enc23, dec23): JsonCodec_core.FieldCodec.t('w),
+    )
+    : JsonCodec_core.Codec.t(
+        (
+          'a,
+          'b,
+          'c,
+          'd,
+          'e,
+          'f,
+          'g,
+          'h,
+          'i,
+          'j,
+          'k,
+          'l,
+          'm,
+          'n,
+          'o,
+          'p,
+          'q,
+          'r,
+          's,
+          't,
+          'u,
+          'v,
+          'w,
+        ),
+      ) => {
+  let encode =
       (
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        v16,
-        v17,
-        v18,
-        v19,
-        v20,
-        v21,
-        v22,
-        v23,
-        v24
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+          v17,
+          v18,
+          v19,
+          v20,
+          v21,
+          v22,
+          v23,
+        ),
       ) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16,
-      enc17 v17,
-      enc18 v18,
-      enc19 v19,
-      enc20 v20,
-      enc21 v21,
-      enc22 v22,
-      enc23 v23,
-      enc24 v24
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+      enc17(v17),
+      enc18(v18),
+      enc19(v19),
+      enc20(v20),
+      enc21(v21),
+      enc22(v22),
+      enc23(v23),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v16 =>
-                                                                    dec17 dict >>= (
-                                                                    fun
+                                                                    dec17(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v17 =>
-                                                                    dec18 dict >>= (
-                                                                    fun
+                                                                    dec18(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v18 =>
-                                                                    dec19 dict >>= (
-                                                                    fun
+                                                                    dec19(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v19 =>
-                                                                    dec20 dict >>= (
-                                                                    fun
+                                                                    dec20(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v20 =>
-                                                                    dec21 dict >>= (
-                                                                    fun
+                                                                    dec21(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v21 =>
-                                                                    dec22 dict >>= (
-                                                                    fun
+                                                                    dec22(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v22 =>
-                                                                    dec23 dict >>= (
-                                                                    fun
+                                                                    dec23(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v23 =>
-                                                                    dec24 dict >>= (
-                                                                    fun
-                                                                    v24 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -2302,9 +2646,7 @@ let object24
                                                                     v21,
                                                                     v22,
                                                                     v23,
-                                                                    v24
-                                                                    )
-                                                                    )
+                                                                    ))
                                                                     )
                                                                     )
                                                                     )
@@ -2329,183 +2671,215 @@ let object24
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object25
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    ((enc17, dec17): JsonCodec_core.FieldCodec.t 'q)
-    ((enc18, dec18): JsonCodec_core.FieldCodec.t 'r)
-    ((enc19, dec19): JsonCodec_core.FieldCodec.t 's)
-    ((enc20, dec20): JsonCodec_core.FieldCodec.t 't)
-    ((enc21, dec21): JsonCodec_core.FieldCodec.t 'u)
-    ((enc22, dec22): JsonCodec_core.FieldCodec.t 'v)
-    ((enc23, dec23): JsonCodec_core.FieldCodec.t 'w)
-    ((enc24, dec24): JsonCodec_core.FieldCodec.t 'x)
-    ((enc25, dec25): JsonCodec_core.FieldCodec.t 'y)
-    :JsonCodec_core.Codec.t (
-       'a,
-       'b,
-       'c,
-       'd,
-       'e,
-       'f,
-       'g,
-       'h,
-       'i,
-       'j,
-       'k,
-       'l,
-       'm,
-       'n,
-       'o,
-       'p,
-       'q,
-       'r,
-       's,
-       't,
-       'u,
-       'v,
-       'w,
-       'x,
-       'y
-     ) => {
-  let encode
+let object24 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+      (enc17, dec17): JsonCodec_core.FieldCodec.t('q),
+      (enc18, dec18): JsonCodec_core.FieldCodec.t('r),
+      (enc19, dec19): JsonCodec_core.FieldCodec.t('s),
+      (enc20, dec20): JsonCodec_core.FieldCodec.t('t),
+      (enc21, dec21): JsonCodec_core.FieldCodec.t('u),
+      (enc22, dec22): JsonCodec_core.FieldCodec.t('v),
+      (enc23, dec23): JsonCodec_core.FieldCodec.t('w),
+      (enc24, dec24): JsonCodec_core.FieldCodec.t('x),
+    )
+    : JsonCodec_core.Codec.t(
+        (
+          'a,
+          'b,
+          'c,
+          'd,
+          'e,
+          'f,
+          'g,
+          'h,
+          'i,
+          'j,
+          'k,
+          'l,
+          'm,
+          'n,
+          'o,
+          'p,
+          'q,
+          'r,
+          's,
+          't,
+          'u,
+          'v,
+          'w,
+          'x,
+        ),
+      ) => {
+  let encode =
       (
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        v16,
-        v17,
-        v18,
-        v19,
-        v20,
-        v21,
-        v22,
-        v23,
-        v24,
-        v25
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+          v17,
+          v18,
+          v19,
+          v20,
+          v21,
+          v22,
+          v23,
+          v24,
+        ),
       ) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16,
-      enc17 v17,
-      enc18 v18,
-      enc19 v19,
-      enc20 v20,
-      enc21 v21,
-      enc22 v22,
-      enc23 v23,
-      enc24 v24,
-      enc25 v25
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+      enc17(v17),
+      enc18(v18),
+      enc19(v19),
+      enc20(v20),
+      enc21(v21),
+      enc22(v22),
+      enc23(v23),
+      enc24(v24),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v16 =>
-                                                                    dec17 dict >>= (
-                                                                    fun
+                                                                    dec17(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v17 =>
-                                                                    dec18 dict >>= (
-                                                                    fun
+                                                                    dec18(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v18 =>
-                                                                    dec19 dict >>= (
-                                                                    fun
+                                                                    dec19(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v19 =>
-                                                                    dec20 dict >>= (
-                                                                    fun
+                                                                    dec20(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v20 =>
-                                                                    dec21 dict >>= (
-                                                                    fun
+                                                                    dec21(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v21 =>
-                                                                    dec22 dict >>= (
-                                                                    fun
+                                                                    dec22(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v22 =>
-                                                                    dec23 dict >>= (
-                                                                    fun
+                                                                    dec23(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v23 =>
-                                                                    dec24 dict >>= (
-                                                                    fun
+                                                                    dec24(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v24 =>
-                                                                    dec25 dict >>= (
-                                                                    fun
-                                                                    v25 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -2530,9 +2904,7 @@ let object25
                                                                     v22,
                                                                     v23,
                                                                     v24,
-                                                                    v25
-                                                                    )
-                                                                    )
+                                                                    ))
                                                                     )
                                                                     )
                                                                     )
@@ -2558,190 +2930,224 @@ let object25
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };
 
-let object26
-    ((enc1, dec1): JsonCodec_core.FieldCodec.t 'a)
-    ((enc2, dec2): JsonCodec_core.FieldCodec.t 'b)
-    ((enc3, dec3): JsonCodec_core.FieldCodec.t 'c)
-    ((enc4, dec4): JsonCodec_core.FieldCodec.t 'd)
-    ((enc5, dec5): JsonCodec_core.FieldCodec.t 'e)
-    ((enc6, dec6): JsonCodec_core.FieldCodec.t 'f)
-    ((enc7, dec7): JsonCodec_core.FieldCodec.t 'g)
-    ((enc8, dec8): JsonCodec_core.FieldCodec.t 'h)
-    ((enc9, dec9): JsonCodec_core.FieldCodec.t 'i)
-    ((enc10, dec10): JsonCodec_core.FieldCodec.t 'j)
-    ((enc11, dec11): JsonCodec_core.FieldCodec.t 'k)
-    ((enc12, dec12): JsonCodec_core.FieldCodec.t 'l)
-    ((enc13, dec13): JsonCodec_core.FieldCodec.t 'm)
-    ((enc14, dec14): JsonCodec_core.FieldCodec.t 'n)
-    ((enc15, dec15): JsonCodec_core.FieldCodec.t 'o)
-    ((enc16, dec16): JsonCodec_core.FieldCodec.t 'p)
-    ((enc17, dec17): JsonCodec_core.FieldCodec.t 'q)
-    ((enc18, dec18): JsonCodec_core.FieldCodec.t 'r)
-    ((enc19, dec19): JsonCodec_core.FieldCodec.t 's)
-    ((enc20, dec20): JsonCodec_core.FieldCodec.t 't)
-    ((enc21, dec21): JsonCodec_core.FieldCodec.t 'u)
-    ((enc22, dec22): JsonCodec_core.FieldCodec.t 'v)
-    ((enc23, dec23): JsonCodec_core.FieldCodec.t 'w)
-    ((enc24, dec24): JsonCodec_core.FieldCodec.t 'x)
-    ((enc25, dec25): JsonCodec_core.FieldCodec.t 'y)
-    ((enc26, dec26): JsonCodec_core.FieldCodec.t 'z)
-    :JsonCodec_core.Codec.t (
-       'a,
-       'b,
-       'c,
-       'd,
-       'e,
-       'f,
-       'g,
-       'h,
-       'i,
-       'j,
-       'k,
-       'l,
-       'm,
-       'n,
-       'o,
-       'p,
-       'q,
-       'r,
-       's,
-       't,
-       'u,
-       'v,
-       'w,
-       'x,
-       'y,
-       'z
-     ) => {
-  let encode
+let object25 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+      (enc17, dec17): JsonCodec_core.FieldCodec.t('q),
+      (enc18, dec18): JsonCodec_core.FieldCodec.t('r),
+      (enc19, dec19): JsonCodec_core.FieldCodec.t('s),
+      (enc20, dec20): JsonCodec_core.FieldCodec.t('t),
+      (enc21, dec21): JsonCodec_core.FieldCodec.t('u),
+      (enc22, dec22): JsonCodec_core.FieldCodec.t('v),
+      (enc23, dec23): JsonCodec_core.FieldCodec.t('w),
+      (enc24, dec24): JsonCodec_core.FieldCodec.t('x),
+      (enc25, dec25): JsonCodec_core.FieldCodec.t('y),
+    )
+    : JsonCodec_core.Codec.t(
+        (
+          'a,
+          'b,
+          'c,
+          'd,
+          'e,
+          'f,
+          'g,
+          'h,
+          'i,
+          'j,
+          'k,
+          'l,
+          'm,
+          'n,
+          'o,
+          'p,
+          'q,
+          'r,
+          's,
+          't,
+          'u,
+          'v,
+          'w,
+          'x,
+          'y,
+        ),
+      ) => {
+  let encode =
       (
-        v1,
-        v2,
-        v3,
-        v4,
-        v5,
-        v6,
-        v7,
-        v8,
-        v9,
-        v10,
-        v11,
-        v12,
-        v13,
-        v14,
-        v15,
-        v16,
-        v17,
-        v18,
-        v19,
-        v20,
-        v21,
-        v22,
-        v23,
-        v24,
-        v25,
-        v26
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+          v17,
+          v18,
+          v19,
+          v20,
+          v21,
+          v22,
+          v23,
+          v24,
+          v25,
+        ),
       ) =>
     Js.Json.object_ @@
-    JsonCodec_util.buildDict [
-      enc1 v1,
-      enc2 v2,
-      enc3 v3,
-      enc4 v4,
-      enc5 v5,
-      enc6 v6,
-      enc7 v7,
-      enc8 v8,
-      enc9 v9,
-      enc10 v10,
-      enc11 v11,
-      enc12 v12,
-      enc13 v13,
-      enc14 v14,
-      enc15 v15,
-      enc16 v16,
-      enc17 v17,
-      enc18 v18,
-      enc19 v19,
-      enc20 v20,
-      enc21 v21,
-      enc22 v22,
-      enc23 v23,
-      enc24 v24,
-      enc25 v25,
-      enc26 v26
-    ];
-  let decode json =>
-    JsonCodec_util.decodeRawObject json >>= (
-      fun dict =>
-        dec1 dict >>= (
-          fun v1 =>
-            dec2 dict >>= (
-              fun v2 =>
-                dec3 dict >>= (
-                  fun v3 =>
-                    dec4 dict >>= (
-                      fun v4 =>
-                        dec5 dict >>= (
-                          fun v5 =>
-                            dec6 dict >>= (
-                              fun v6 =>
-                                dec7 dict >>= (
-                                  fun v7 =>
-                                    dec8 dict >>= (
-                                      fun v8 =>
-                                        dec9 dict >>= (
-                                          fun v9 =>
-                                            dec10 dict >>= (
-                                              fun v10 =>
-                                                dec11 dict >>= (
-                                                  fun v11 =>
-                                                    dec12 dict >>= (
-                                                      fun v12 =>
-                                                        dec13 dict >>= (
-                                                          fun v13 =>
-                                                            dec14 dict >>= (
-                                                              fun v14 =>
-                                                                dec15 dict >>= (
-                                                                  fun
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+      enc17(v17),
+      enc18(v18),
+      enc19(v19),
+      enc20(v20),
+      enc21(v21),
+      enc22(v22),
+      enc23(v23),
+      enc24(v24),
+      enc25(v25),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
                                                                   v15 =>
-                                                                    dec16 dict >>= (
-                                                                    fun
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v16 =>
-                                                                    dec17 dict >>= (
-                                                                    fun
+                                                                    dec17(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v17 =>
-                                                                    dec18 dict >>= (
-                                                                    fun
+                                                                    dec18(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v18 =>
-                                                                    dec19 dict >>= (
-                                                                    fun
+                                                                    dec19(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v19 =>
-                                                                    dec20 dict >>= (
-                                                                    fun
+                                                                    dec20(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v20 =>
-                                                                    dec21 dict >>= (
-                                                                    fun
+                                                                    dec21(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v21 =>
-                                                                    dec22 dict >>= (
-                                                                    fun
+                                                                    dec22(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v22 =>
-                                                                    dec23 dict >>= (
-                                                                    fun
+                                                                    dec23(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v23 =>
-                                                                    dec24 dict >>= (
-                                                                    fun
+                                                                    dec24(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v24 =>
-                                                                    dec25 dict >>= (
-                                                                    fun
+                                                                    dec25(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
                                                                     v25 =>
-                                                                    dec26 dict >>= (
-                                                                    fun
-                                                                    v26 =>
-                                                                    Js.Result.Ok (
+                                                                    Js.Result.Ok((
                                                                     v1,
                                                                     v2,
                                                                     v3,
@@ -2767,8 +3173,287 @@ let object26
                                                                     v23,
                                                                     v24,
                                                                     v25,
-                                                                    v26
+                                                                    ))
                                                                     )
+                                                                    )
+                                                                    )
+                                                                    )
+                                                                    )
+                                                                    )
+                                                                    )
+                                                                    )
+                                                                    )
+                                                                    )
+                                                                )
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    );
+  (encode, decode);
+};
+
+let object26 =
+    (
+      (enc1, dec1): JsonCodec_core.FieldCodec.t('a),
+      (enc2, dec2): JsonCodec_core.FieldCodec.t('b),
+      (enc3, dec3): JsonCodec_core.FieldCodec.t('c),
+      (enc4, dec4): JsonCodec_core.FieldCodec.t('d),
+      (enc5, dec5): JsonCodec_core.FieldCodec.t('e),
+      (enc6, dec6): JsonCodec_core.FieldCodec.t('f),
+      (enc7, dec7): JsonCodec_core.FieldCodec.t('g),
+      (enc8, dec8): JsonCodec_core.FieldCodec.t('h),
+      (enc9, dec9): JsonCodec_core.FieldCodec.t('i),
+      (enc10, dec10): JsonCodec_core.FieldCodec.t('j),
+      (enc11, dec11): JsonCodec_core.FieldCodec.t('k),
+      (enc12, dec12): JsonCodec_core.FieldCodec.t('l),
+      (enc13, dec13): JsonCodec_core.FieldCodec.t('m),
+      (enc14, dec14): JsonCodec_core.FieldCodec.t('n),
+      (enc15, dec15): JsonCodec_core.FieldCodec.t('o),
+      (enc16, dec16): JsonCodec_core.FieldCodec.t('p),
+      (enc17, dec17): JsonCodec_core.FieldCodec.t('q),
+      (enc18, dec18): JsonCodec_core.FieldCodec.t('r),
+      (enc19, dec19): JsonCodec_core.FieldCodec.t('s),
+      (enc20, dec20): JsonCodec_core.FieldCodec.t('t),
+      (enc21, dec21): JsonCodec_core.FieldCodec.t('u),
+      (enc22, dec22): JsonCodec_core.FieldCodec.t('v),
+      (enc23, dec23): JsonCodec_core.FieldCodec.t('w),
+      (enc24, dec24): JsonCodec_core.FieldCodec.t('x),
+      (enc25, dec25): JsonCodec_core.FieldCodec.t('y),
+      (enc26, dec26): JsonCodec_core.FieldCodec.t('z),
+    )
+    : JsonCodec_core.Codec.t(
+        (
+          'a,
+          'b,
+          'c,
+          'd,
+          'e,
+          'f,
+          'g,
+          'h,
+          'i,
+          'j,
+          'k,
+          'l,
+          'm,
+          'n,
+          'o,
+          'p,
+          'q,
+          'r,
+          's,
+          't,
+          'u,
+          'v,
+          'w,
+          'x,
+          'y,
+          'z,
+        ),
+      ) => {
+  let encode =
+      (
+        (
+          v1,
+          v2,
+          v3,
+          v4,
+          v5,
+          v6,
+          v7,
+          v8,
+          v9,
+          v10,
+          v11,
+          v12,
+          v13,
+          v14,
+          v15,
+          v16,
+          v17,
+          v18,
+          v19,
+          v20,
+          v21,
+          v22,
+          v23,
+          v24,
+          v25,
+          v26,
+        ),
+      ) =>
+    Js.Json.object_ @@
+    JsonCodec_util.buildDict([
+      enc1(v1),
+      enc2(v2),
+      enc3(v3),
+      enc4(v4),
+      enc5(v5),
+      enc6(v6),
+      enc7(v7),
+      enc8(v8),
+      enc9(v9),
+      enc10(v10),
+      enc11(v11),
+      enc12(v12),
+      enc13(v13),
+      enc14(v14),
+      enc15(v15),
+      enc16(v16),
+      enc17(v17),
+      enc18(v18),
+      enc19(v19),
+      enc20(v20),
+      enc21(v21),
+      enc22(v22),
+      enc23(v23),
+      enc24(v24),
+      enc25(v25),
+      enc26(v26),
+    ]);
+  let decode = json =>
+    JsonCodec_util.decodeRawObject(json)
+    >>= (
+      dict =>
+        dec1(dict)
+        >>= (
+          v1 =>
+            dec2(dict)
+            >>= (
+              v2 =>
+                dec3(dict)
+                >>= (
+                  v3 =>
+                    dec4(dict)
+                    >>= (
+                      v4 =>
+                        dec5(dict)
+                        >>= (
+                          v5 =>
+                            dec6(dict)
+                            >>= (
+                              v6 =>
+                                dec7(dict)
+                                >>= (
+                                  v7 =>
+                                    dec8(dict)
+                                    >>= (
+                                      v8 =>
+                                        dec9(dict)
+                                        >>= (
+                                          v9 =>
+                                            dec10(dict)
+                                            >>= (
+                                              v10 =>
+                                                dec11(dict)
+                                                >>= (
+                                                  v11 =>
+                                                    dec12(dict)
+                                                    >>= (
+                                                      v12 =>
+                                                        dec13(dict)
+                                                        >>= (
+                                                          v13 =>
+                                                            dec14(dict)
+                                                            >>= (
+                                                              v14 =>
+                                                                dec15(dict)
+                                                                >>= (
+                                                                  v15 =>
+                                                                    dec16(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v16 =>
+                                                                    dec17(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v17 =>
+                                                                    dec18(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v18 =>
+                                                                    dec19(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v19 =>
+                                                                    dec20(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v20 =>
+                                                                    dec21(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v21 =>
+                                                                    dec22(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v22 =>
+                                                                    dec23(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v23 =>
+                                                                    dec24(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v24 =>
+                                                                    dec25(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v25 =>
+                                                                    dec26(
+                                                                    dict,
+                                                                    )
+                                                                    >>= (
+                                                                    v26 =>
+                                                                    Js.Result.Ok((
+                                                                    v1,
+                                                                    v2,
+                                                                    v3,
+                                                                    v4,
+                                                                    v5,
+                                                                    v6,
+                                                                    v7,
+                                                                    v8,
+                                                                    v9,
+                                                                    v10,
+                                                                    v11,
+                                                                    v12,
+                                                                    v13,
+                                                                    v14,
+                                                                    v15,
+                                                                    v16,
+                                                                    v17,
+                                                                    v18,
+                                                                    v19,
+                                                                    v20,
+                                                                    v21,
+                                                                    v22,
+                                                                    v23,
+                                                                    v24,
+                                                                    v25,
+                                                                    v26,
+                                                                    ))
                                                                     )
                                                                     )
                                                                     )
@@ -2796,5 +3481,5 @@ let object26
             )
         )
     );
-  (encode, decode)
+  (encode, decode);
 };

--- a/src/jsonCodec_result.re
+++ b/src/jsonCodec_result.re
@@ -1,21 +1,21 @@
 include Js.Result;
 
-let fromOption (o: option 'a) (error: 'b) :t 'a 'b =>
-  switch o {
-  | Some x => Ok x
-  | None => Error error
+let fromOption = (o: option('a), error: 'b) : t('a, 'b) =>
+  switch (o) {
+  | Some(x) => Ok(x)
+  | None => Error(error)
   };
 
-let map (f: 'a => 'b) (result: t 'a 'c) :t 'b 'c =>
-  switch result {
-  | Ok x => Ok (f x)
-  | Error y => Error y
+let map = (f: 'a => 'b, result: t('a, 'c)) : t('b, 'c) =>
+  switch (result) {
+  | Ok(x) => Ok(f(x))
+  | Error(y) => Error(y)
   };
 
 module Ops = {
-  let (>>=) (result: t 'a 'c) (f: 'a => t 'b 'c) :t 'b 'c =>
-    switch result {
-    | Ok x => f x
-    | Error y => Error y
+  let (>>=) = (result: t('a, 'c), f: 'a => t('b, 'c)) : t('b, 'c) =>
+    switch (result) {
+    | Ok(x) => f(x)
+    | Error(y) => Error(y)
     };
 };

--- a/src/jsonCodec_util.re
+++ b/src/jsonCodec_util.re
@@ -2,73 +2,82 @@ module Result = JsonCodec_result;
 
 open Result.Ops;
 
-let parseJson s =>
-  try (Result.Ok (Js.Json.parseExn s)) {
-  | Js.Exn.Error e => Result.Error (Js.Exn.message e |> Js.Option.default "JSON parsing failed")
+let parseJson = s =>
+  try (Result.Ok(Js.Json.parseExn(s))) {
+  | Js.Exn.Error(e) =>
+    Result.Error(
+      Js.Exn.message(e) |> Js.Option.default("JSON parsing failed"),
+    )
   };
 
-external formatJson : Js.Json.t => _ [@bs.as {json|null|json}] => int => string =
-  "stringify" [@@bs.val] [@@bs.scope "JSON"];
+[@bs.val] [@bs.scope "JSON"]
+external formatJson : (Js.Json.t, [@bs.as {json|null|json}] _, int) => string =
+  "stringify";
 
-let decodeArrayElements decode elements => {
-  let length = Js.Array.length elements;
+let decodeArrayElements = (decode, elements) => {
+  let length = Js.Array.length(elements);
   let output = [||];
-  let rec loop i =>
+  let rec loop = i =>
     if (i == length) {
-      Result.Ok output
+      Result.Ok(output);
     } else {
-      switch (decode elements.(i)) {
-      | Result.Ok decoded =>
-        ignore (Js.Array.push decoded output);
-        loop (i + 1)
-      | Result.Error error => Result.Error error
-      }
+      switch (decode(elements[i])) {
+      | Result.Ok(decoded) =>
+        ignore(Js.Array.push(decoded, output));
+        loop(i + 1);
+      | Result.Error(error) => Result.Error(error)
+      };
     };
-  loop 0
+  loop(0);
 };
 
-let decoderOf f error x => Result.fromOption (f x) error;
+let decoderOf = (f, error, x) => Result.fromOption(f(x), error);
 
-let decodeRawObject = decoderOf Js.Json.decodeObject "Expected object";
+let decodeRawObject = decoderOf(Js.Json.decodeObject, "Expected object");
 
-let decodeRawArray = decoderOf Js.Json.decodeArray "Expected array";
+let decodeRawArray = decoderOf(Js.Json.decodeArray, "Expected array");
 
-let decodeRawNumber = decoderOf Js.Json.decodeNumber "Expected number";
+let decodeRawNumber = decoderOf(Js.Json.decodeNumber, "Expected number");
 
-let decodeRawBool = decoderOf Js.Json.decodeBoolean "Expected boolean";
+let decodeRawBool = decoderOf(Js.Json.decodeBoolean, "Expected boolean");
 
-let decodeRawString = decoderOf Js.Json.decodeString "Expected string";
+let decodeRawString = decoderOf(Js.Json.decodeString, "Expected string");
 
-let decodeRawNull = decoderOf Js.Json.decodeNull "Expected null";
+let decodeRawNull = decoderOf(Js.Json.decodeNull, "Expected null");
 
-let validInt (x: float) => {
-  let xInt = int_of_float x;
-  if (x == float_of_int xInt) {
-    Result.Ok x
+let validInt = (x: float) => {
+  let xInt = int_of_float(x);
+  if (x == float_of_int(xInt)) {
+    Result.Ok(x);
   } else {
-    Result.Error ("Not an int: " ^ string_of_float x)
-  }
+    Result.Error("Not an int: " ++ string_of_float(x));
+  };
 };
 
-let decodeMandatoryField decode name dict =>
-  Result.fromOption (Js.Dict.get dict name) ("Field '" ^ name ^ "' not found") >>= decode;
+let decodeMandatoryField = (decode, name, dict) =>
+  Result.fromOption(
+    Js.Dict.get(dict, name),
+    "Field '" ++ name ++ "' not found",
+  )
+  >>= decode;
 
-let decodeOptionalField decode name dict =>
-  Result.Ok (Js.Dict.get dict name) >>= (
+let decodeOptionalField = (decode, name, dict) =>
+  Result.Ok(Js.Dict.get(dict, name))
+  >>= (
     fun
-    | Some x => decode x |> Result.map Js.Option.some
-    | None => Result.Ok None
+    | Some(x) => decode(x) |> Result.map(Js.Option.some)
+    | None => Result.Ok(None)
   );
 
-let buildDict fields => {
-  let dict = Js.Dict.empty ();
-  let rec loop remaining =>
-    switch remaining {
+let buildDict = fields => {
+  let dict = Js.Dict.empty();
+  let rec loop = remaining =>
+    switch (remaining) {
     | [] => dict
-    | [Some (name, value), ...tail] =>
-      Js.Dict.set dict name value;
-      loop tail
-    | [None, ...tail] => loop tail
+    | [Some((name, value)), ...tail] =>
+      Js.Dict.set(dict, name, value);
+      loop(tail);
+    | [None, ...tail] => loop(tail)
     };
-  loop fields
+  loop(fields);
 };

--- a/src/jsonCodec_xor.re
+++ b/src/jsonCodec_xor.re
@@ -1,22 +1,22 @@
 module Function = JsonCodec_function;
 
-type t 'a 'b =
-  | Left 'a
-  | Right 'b;
+type t('a, 'b) =
+  | Left('a)
+  | Right('b);
 
-let left a :t 'a 'b => Left a;
+let left = a : t('a, 'b) => Left(a);
 
-let right b :t 'a 'b => Right b;
+let right = b : t('a, 'b) => Right(b);
 
-let either f g xor =>
-  switch xor {
-  | Left x => f x
-  | Right y => g y
+let either = (f, g, xor) =>
+  switch (xor) {
+  | Left(x) => f(x)
+  | Right(y) => g(y)
   };
 
-let toOption x => either (Function.const None) Js.Option.some @@ x;
+let toOption = x => either(Function.const(None), Js.Option.some) @@ x;
 
 let fromOption =
   fun
-  | Some x => right x
-  | None => left ();
+  | Some(x) => right(x)
+  | None => left();


### PR DESCRIPTION
Latest update of Bucklescript (bs-platform 2.2.3) removed support for Reason v2 syntax and broke my code.
https://github.com/BuckleScript/bucklescript/blob/master/Changes.md#223
Updated syntax to v3 latest, supported only in bs-platform 2.2.3

Included tests and my own app's tests are fine, but bsrefmt v2.2.2 does not work. Only 2.2.3